### PR TITLE
fix: import error on Windows (fix #1)

### DIFF
--- a/packages/histoire/src/node/plugin.ts
+++ b/packages/histoire/src/node/plugin.ts
@@ -40,8 +40,8 @@ export async function createVitePlugins (ctx: Context): Promise<Plugin[]> {
 
     load (id) {
       if (id === RESOLVED_STORIES_ID) {
-        return `${stories.map((story, index) => `import Comp${index} from '/${story.file}'`).join('\n')}
-export let files = [${stories.map((story, index) => `{ id: '${story.id}', file: '/${story.file}', component: Comp${index} }`).join(',\n')}]
+        return `${stories.map((story, index) => `import Comp${index} from '${story.file}'`).join('\n')}
+export let files = [${stories.map((story, index) => `{ id: '${story.id}', file: '${story.file}', component: Comp${index} }`).join(',\n')}]
 const handlers = []
 export function onUpdate (cb) {
   handlers.push(cb)

--- a/packages/histoire/src/node/stories.ts
+++ b/packages/histoire/src/node/stories.ts
@@ -2,6 +2,7 @@ import { Context } from './context.js'
 import chokidar from 'chokidar'
 import { globby } from 'globby'
 import Case from 'case'
+import { join } from 'pathe'
 
 export interface Story {
   id: string
@@ -21,7 +22,8 @@ export async function watchStories (ctx: Context) {
     cwd: ctx.config.sourceDir,
   })
   watcher.on('add', (file) => {
-    addStory(file)
+    const absoluteFilePath = join(ctx.config.sourceDir, file)
+    addStory(absoluteFilePath)
     notifyChange()
   })
   watcher.on('unlink', (file) => {


### PR DESCRIPTION
Fix #1 

### Description

Windows has a hard time with slash and backslash on file paths. I used absolute path and pathe to make sure it uses slash.
Histoire now work flawlessly on Windows 🥳 !

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other