### PR TITLE
feat: Handle files and folders title conflict (fix #57)

### DIFF
--- a/packages/histoire/src/node/tree.spec.ts
+++ b/packages/histoire/src/node/tree.spec.ts
@@ -25,4 +25,65 @@ describe('makeTree', () => {
       { title: 'hi', index: 0 },
     ])
   })
+
+  test('should handle title conflict', () => {
+    const config = getDefaultConfig()
+    const files = [
+      { index: 0, path: ['hi'] },
+      { index: 1, path: ['hi'] },
+      { index: 2, path: ['hi'] },
+    ]
+
+    const tree = makeTree(config, files)
+
+    expect(tree).toEqual([
+      { title: 'hi', index: 0 },
+      { title: 'hi-1', index: 1 },
+      { title: 'hi-2', index: 2 },
+    ])
+  })
+
+  test('should handle file-folder conflict when folder in first', () => {
+    const config = getDefaultConfig()
+    const files = [
+      { index: 0, path: ['hi', 'dad'] },
+      { index: 1, path: ['hi'] },
+      { index: 2, path: ['hi', 'mom'] },
+    ]
+
+    const tree = makeTree(config, files)
+
+    expect(tree).toEqual([
+      {
+        title: 'hi',
+        children: [
+          { title: 'dad', index: 0 },
+          { title: 'mom', index: 2 },
+        ],
+      },
+      { title: 'hi-1', index: 1 },
+    ])
+  })
+
+  test('should handle file-folder conflict when file in first', () => {
+    const config = getDefaultConfig()
+    const files = [
+      { index: 0, path: ['hi'] },
+      { index: 1, path: ['hi', 'dad'] },
+      { index: 2, path: ['hi', 'mom'] },
+    ]
+
+    const tree = makeTree(config, files)
+
+    expect(tree).toEqual([
+      {
+        title: 'hi',
+        children: [
+          { title: 'dad', index: 1 },
+          { title: 'mom', index: 2 },
+        ],
+      },
+      { title: 'hi-1', index: 0 },
+    ])
+  })
 })

--- a/packages/histoire/src/node/tree.ts
+++ b/packages/histoire/src/node/tree.ts
@@ -51,17 +51,41 @@ export function makeTree (config: HistoireConfig, files: { path: string[], index
 
   return buildTree(treeObject)
 
-  // Undefined behavior for folder and file that share the same name under the same directory
   function setPath (path: string[], value: unknown, tree: unknown) {
     path.reduce((subtree, key, i) => {
-      if (!subtree[key]) {
-        subtree[key] = {}
-      }
       if (i === path.length - 1) {
-        subtree[key] = value
+        setKey(subtree, key, value)
+      } else if (isLeaf(subtree[key])) {
+        setKey(subtree, key, subtree[key])
+        subtree[key] = {}
+      } else if (!subtree[key]) {
+        subtree[key] = {}
       }
       return subtree[key]
     }, tree)
+
+    function isLeaf (element) {
+      return !isNaN(element)
+    }
+  }
+
+  function setKey (tree, key, value) {
+    if (isUndefined(tree[key])) {
+      tree[key] = value
+      return
+    }
+
+    let copyNumber = 1
+
+    while (!isUndefined(tree[`${key}-${copyNumber}`])) {
+      copyNumber++
+    }
+
+    tree[`${key}-${copyNumber}`] = value
+
+    function isUndefined (element) {
+      return element === undefined
+    }
   }
 
   function buildTree (treeObject: ITreeObject): Tree {


### PR DESCRIPTION
fix https://github.com/histoire-dev/histoire/issues/57

### Description

I ended just making it work, so that the user can still choose whatever name he want.
Files AND folder with the same name "just work".

The conflicting name just have a trailing number to their IDs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
