### PR TITLE
docs: add examples (fix #91)

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -85,6 +85,23 @@ module.exports = {
           ],
         },
         {
+          text: 'Examples',
+          children: [
+            {
+              text: 'Single stories',
+              link: '/guide/examples/single-stories',
+            },
+            {
+              text: 'Variant stories',
+              link: '/guide/examples/variant-stories',
+            },
+            {
+              text: 'Controlled stories',
+              link: '/guide/examples/controlled-stories',
+            },
+          ],
+        },
+        {
           text: 'Plugins',
           link: '/guide/plugins',
         },

--- a/docs/guide/examples/controlled-stories.md
+++ b/docs/guide/examples/controlled-stories.md
@@ -1,0 +1,140 @@
+# Controlled stories
+
+These patterns let you create custom controls to update your component
+
+## Single control
+
+This will display a control panel for the story.
+
+```vue
+<script lang="ts" setup>
+import { reactive } from 'vue'
+import MyComponent from './MyComponent.vue'
+
+const state = reactive({
+  text: "Hello world"
+})
+
+defineExpose({
+  state
+})
+</script>
+
+<template>
+  <Story title="MyStory">
+    <MyComponent :argument="state.text" />
+    <template #controls>
+      <HstText v-model="state.text" title="Content" />
+    </template>
+  </Story>
+</template>
+```
+
+## Global variant control
+
+This will display a control panel for all the variants.
+
+```vue
+<script lang="ts" setup>
+import { reactive } from 'vue'
+import MyComponent from './MyComponent.vue'
+
+const state = reactive({
+  text: "Hello world"
+})
+
+defineExpose({
+  state
+})
+</script>
+
+<template>
+  <Story title="MyStory">
+    <Variant title="MyVariant Red">
+      <MyComponent :argument="state.text" color="red" />
+    </Variant>
+    <Variant title="MyVariant Blue">
+      <MyComponent :argument="state.text" color="blue" />
+    </Variant>
+    <template #controls>
+      <HstText v-model="state.text" title="Content" />
+    </template>
+  </Story>
+</template>
+```
+
+## Specific variant control
+
+This will display a control panel only for one variant.
+
+```vue
+<script lang="ts" setup>
+import { reactive } from 'vue'
+import MyComponent from './MyComponent.vue'
+
+const state = reactive({
+  text: "Hello world"
+})
+
+defineExpose({
+  state
+})
+</script>
+
+<template>
+  <Story title="MyStory">
+    <Variant title="MyVariant Red">
+      <MyComponent :argument="state.text" color="red" />
+      <template #controls>
+        <HstText v-model="state.text" title="Content" />
+      </template>
+    </Variant>
+    <Variant title="MyVariant Blue">
+      <MyComponent argument="hello" color="blue" />
+    </Variant>
+  </Story>
+</template>
+```
+
+## Isolated variant control
+
+This will isolate each variant so that you control only one variant at a time.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+
+function initState () {
+  return {
+    text: "Hello world"
+  }
+}
+</script>
+
+<template>
+  <Story title="MyStory">
+    <Variant 
+      title="MyVariant Red"
+      :init-state="initState"
+    >
+      <template #default="{ state }">
+        <MyComponent :argument="state.text" color="red" />
+      </template>
+      <template #controls="{ state }">
+        <HstText v-model="state.text" title="Content" />
+      </template>
+    </Variant>
+    <Variant
+      title="MyVariant Blue"
+      :init-state="initState"
+    >
+      <template #default="{ state }">
+        <MyComponent :argument="state.text" color="blue" />
+      </template>
+      <template #controls="{ state }">
+        <HstText v-model="state.text" title="Content" />
+      </template>
+    </Variant>
+  </Story>
+</template>
+```

--- a/docs/guide/examples/single-stories.md
+++ b/docs/guide/examples/single-stories.md
@@ -1,0 +1,39 @@
+# Single stories
+
+Here are some pattern examples to test your component without any variant. This is the simplest way to get you started.
+
+## Within an iframe
+
+This will display your component inside an iframe to be able to test the responsiveness correctly. The iframe is needed for CSS media queries to work properly.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+</script>
+
+<template>
+  <Story title="MyStory">
+    <MyComponent />
+  </Story>
+</template>
+```
+
+## Integrated
+
+This will integrate your component directly in the app. The advantage being that you can pass complex arguments (such as functions or recursive object), but responsiveness won't work for CSS media queries.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+</script>
+
+<template>
+  <Story
+    title="MyStory"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <MyComponent />
+  </Story>
+</template>
+```
+

--- a/docs/guide/examples/variant-stories.md
+++ b/docs/guide/examples/variant-stories.md
@@ -1,0 +1,106 @@
+# Story with variants
+
+These patterns let you create several variants of your component to visualize several state of your component.
+
+## Isolated
+
+This will display variants as separate pages that you can navigate into. This view will be the same as single stories, and you will be able to resize your components.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+</script>
+
+<template>
+  <Story title="MyStory">
+    <Variant title="MyVariant 1">
+      <MyComponent argument="hello" />
+    </Variant>
+    <Variant title="MyVariant 2">
+      <MyComponent argument="world" />
+    </Variant>
+  </Story>
+</template>
+```
+
+## Grid
+
+This will display variants in a grid for you to visualize all the variants in the same page. Though, you must fix the width (it can be a percentage).
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+</script>
+
+<template>
+  <Story
+    title="MyStory"
+    :layout="{ type: 'grid', width: '200px' }"
+  >
+    <Variant title="MyVariant 1">
+      <MyComponent argument="hello" />
+    </Variant>
+    <Variant title="MyVariant 2">
+      <MyComponent argument="world" />
+    </Variant>
+  </Story>
+</template>
+```
+
+## Auto generated grid
+
+When you have a lot of variant to test, it can be easier to auto generated them with this pattern.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+
+const arguments = ["hello", "world", "etc", "..."];
+</script>
+
+<template>
+  <Story
+    title="MyStory"
+    :layout="{ type: 'grid', width: '200px' }"
+  >
+    <Variant
+      v-for="(argument, key) of arguments"
+      :key="key"
+      :title="'MyVariant ' + key"
+    >
+      <MyComponent :argument="argument" />
+    </Variant>
+  </Story>
+</template>
+```
+
+## Auto generated grid with props binding
+
+When your variants have a lot of arguments, you can use this pattern.
+
+```vue
+<script lang="ts" setup>
+import MyComponent from './MyComponent.vue'
+
+const propsVariants = [
+  { argument: "hello", color: "red", count:4 },
+  { argument: "world", color: "blue", count:5 },
+  { argument: "etc", color: "violet", count:6 },
+];
+</script>
+
+<template>
+  <Story
+    title="MyStory"
+    :layout="{ type: 'grid', width: '200px' }"
+  >
+    <Variant
+      v-for="(props, key) of propsVariants"
+      :key="key"
+      :title="'MyVariant ' + key"
+    >
+      <MyComponent v-bind="props" />
+    </Variant>
+  </Story>
+</template>
+```

--- a/docs/guide/vue3/controls.md
+++ b/docs/guide/vue3/controls.md
@@ -46,7 +46,7 @@ export default defineComponent({
 Example with Composition API:
 
 ```vue{18-22}
-<script lang="ts" setup>
+<script lang="ts">
 import { reactive, count } from 'vue'
 import MyButton from './MyButton.vue'
 


### PR DESCRIPTION
Fix #91 

### Description

Just added a few examples/snippet to ease stories creation.
Preview: https://deploy-preview-95--histoire-site.netlify.app/guide/examples/single-stories.html

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other