### PR TITLE
docs: fix typo in @histoire/plugin-nuxt import statement

### DIFF
--- a/packages/histoire-plugin-nuxt/README.md
+++ b/packages/histoire-plugin-nuxt/README.md
@@ -7,12 +7,10 @@ pnpm add -D @histoire/plugin-nuxt
 Add the plugin in histoire config:
 
 ```js
-import { defineConfig } from 'histoire'
-import { HstNuxt } from '@histoire/plugin-pnuxtercy'
+import { defineConfig } from "histoire";
+import { HstNuxt } from "@histoire/plugin-nuxt";
 
 export default defineConfig({
-  plugins: [
-    HstNuxt(),
-  ],
-})
+  plugins: [HstNuxt()],
+});
 ```


### PR DESCRIPTION
### Description

Fix small typo in `packages/histoire-plugin-nuxt/README.md`.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
