### PR TITLE
feat: add viteNodeTransformMode config option, fix #108

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -288,6 +288,36 @@ export default defineConfig({
 })
 ```
 
+## `viteNodeTransformMode`
+
+`{ web?, ssr? }`
+
+Determine the transform method of modules
+
+### `viteNodeTransformMode.ssr`
+
+`RegExp[]` - Default: `[/\.([cm]?[jt]sx?|json)$/]`
+
+Use SSR transform pipeline for the specified files.<br>
+Vite plugins will receive `ssr: true` flag when processing those files.
+
+### `viteNodeTransformMode.web`
+
+`RegExp[]` - Default: *modules other than those specified in `transformMode.ssr`*
+
+First do a normal transform pipeline (targeting browser), then do a SSR rewrite to run the code in Node.<br>
+Vite plugins will receive `ssr: false` flag when processing those files.
+
+When you use JSX as component models other than React (e.g. Vue JSX or SolidJS), you might want to config as following to make `.tsx` / `.jsx` transformed as client-side components:
+
+```ts
+export default defineConfig({
+  viteNodeTransformMode: {
+    web: [/\.[jt]sx$/],
+  },
+})
+```
+
 ## `viteNodeInlineDeps`
 
 `RegExp[]`

--- a/packages/histoire/src/node/collect/index.ts
+++ b/packages/histoire/src/node/collect/index.ts
@@ -28,6 +28,7 @@ export function useCollectStories (options: UseCollectStoriesOptions, ctx: Conte
         ...ctx.config.viteNodeInlineDeps ?? [],
       ],
     },
+    transformMode: ctx.config.viteNodeTransformMode,
   })
 
   const threadsCount = ctx.mode === 'dev'

--- a/packages/histoire/src/node/config.ts
+++ b/packages/histoire/src/node/config.ts
@@ -153,6 +153,26 @@ export interface HistoireConfig {
    * Transpile dependencies when collecting stories on Node.js
    */
   viteNodeInlineDeps?: RegExp[]
+  /**
+   * Determine the transform method of modules
+   */
+  viteNodeTransformMode?: {
+    /**
+     * Use SSR transform pipeline for the specified files.
+     * Vite plugins will receive `ssr: true` flag when processing those files.
+     *
+     * @default [/\.([cm]?[jt]sx?|json)$/]
+     */
+    ssr?: RegExp[]
+    /**
+     * First do a normal transform pipeline (targeting browser),
+     * then then do a SSR rewrite to run the code in Node.
+     * Vite plugins will receive `ssr: false` flag when processing those files.
+     *
+     * @default other than `ssr`
+     */
+    web?: RegExp[]
+  }
 }
 
 export type ConfigMode = 'build' | 'dev'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #108

I've added ViteNode's workaround for processing files under `web` flag (`ssr: false`). By default, most of the files are processed with `ssr: true`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
