### PR TITLE
fix(a11y): make font-size follow user brower settings

### DIFF
--- a/packages/histoire-controls/src/style/main.css
+++ b/packages/histoire-controls/src/style/main.css
@@ -6,12 +6,12 @@
 
 
 body {
-  font-size: 18px;
+  font-size: 1.125rem;
   @apply dark:htw-text-gray-100;
 }
 
 @media (min-width: 640px) {
   body {
-    font-size: 14px;
+    font-size: .875rem;
   }
 }

--- a/packages/histoire/src/client/app/components/base/BaseSplitPane.vue
+++ b/packages/histoire/src/client/app/components/base/BaseSplitPane.vue
@@ -206,11 +206,11 @@ onUnmounted(() => {
 
 <style lang="postcss" scoped>
 .landscape > div > .dragger {
-  width: 10px;
+  width: .625rem;
 }
 
 .portrait > div > .dragger {
-  height: 10px;
+  height: .625rem;
 }
 
 .landscape > div > .dragger.dragger-offset-before {
@@ -222,18 +222,18 @@ onUnmounted(() => {
 }
 
 .landscape > div > .dragger.dragger-offset-center {
-  right: -5px;
+  right: -.3125rem;
 }
 
 .portrait > div > .dragger.dragger-offset-center {
-  bottom: -5px;
+  bottom: -.3125rem;
 }
 
 .landscape > div > .dragger.dragger-offset-after {
-  right: -10px;
+  right: -.625rem;
 }
 
 .portrait > div > .dragger.dragger-offset-after {
-  bottom: -10px;
+  bottom: -.625rem;
 }
 </style>

--- a/packages/histoire/src/client/app/style/main.pcss
+++ b/packages/histoire/src/client/app/style/main.pcss
@@ -50,16 +50,16 @@ body,
 
 html {
   font-family: 'Lato', sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 body {
-  font-size: 18px;
+  font-size: 1.125rem;
 }
 
 @media (min-width: 640px) {
   body {
-    font-size: 14px;
+    font-size: .875rem;
   }
 }
 

--- a/packages/histoire/src/client/app/style/sandbox.css
+++ b/packages/histoire/src/client/app/style/sandbox.css
@@ -10,7 +10,7 @@ body {
 }
 
 html {
-  font-size: 14px;
+  font-size: .875rem;
   font-family: 'Lato', sans-serif;
 }
 

--- a/packages/histoire/tailwind.config.cjs
+++ b/packages/histoire/tailwind.config.cjs
@@ -100,7 +100,7 @@ module.exports.theme.extend.typography = (theme) => ({
         marginLeft: 0,
         marginRight: 0,
         backgroundColor: theme('colors.gray-100'),
-        padding: '4px 6px',
+        padding: '.25rem .375rem',
 
         '& p:first-child': {
           marginTop: 0,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The browser's font resizing feature is one of the commonly used accessibility features. And it is disabled when the font size is set to `px`. The workaround is rem which uses root-based size units .

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The change before and after the modification when I resized the font to extra large.

<table>
<tr><td>

### Before

![image](https://user-images.githubusercontent.com/45708948/172040800-f207b512-79b0-4985-a9c2-694a63c972c0.png)

</td>
<td>

### After

![image](https://user-images.githubusercontent.com/45708948/172040792-f8af3bf7-be90-41fb-8ff7-dd1ecc59f045.png)

</td></tr></table>

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
