### PR TITLE
fix: stringify functions in `toRawDeep`

### DIFF
--- a/packages/histoire/src/client/app/util/state.ts
+++ b/packages/histoire/src/client/app/util/state.ts
@@ -2,15 +2,11 @@ import { unref, isRef } from 'vue'
 
 const isObject = (val) => val !== null && typeof val === 'object'
 
-export function toRawDeep(val, seen = new Set()) {
+export function toRawDeep (val, seen = new Set()) {
   const unwrappedValue = isRef(val) ? unref(val) : val
   const valueType = typeof unwrappedValue
 
-  if (valueType === 'symbol') {
-    return unwrappedValue.toString()
-  }
-
-  if (valueType === 'function') {
+  if (valueType === 'symbol' || valueType === 'function') {
     return unwrappedValue.toString()
   }
 
@@ -25,16 +21,13 @@ export function toRawDeep(val, seen = new Set()) {
   seen.add(unwrappedValue)
 
   if (Array.isArray(unwrappedValue)) {
-    return unwrappedValue
-      .map((value) => toRawDeep(value, seen))
-      .filter((val) => val !== void 0)
+    return unwrappedValue.map(value => toRawDeep(value, seen))
   }
 
   return toRawObject(unwrappedValue, seen)
 }
 
-const toRawObject = (obj: Record<any, any>, seen = new Set()) =>
-  Object.keys(obj).reduce((raw, key) => {
-    raw[key] = toRawDeep(obj[key], seen)
-    return raw
-  }, {})
+const toRawObject = (obj: Record<any, any>, seen = new Set()) => Object.keys(obj).reduce((raw, key) => {
+  raw[key] = toRawDeep(obj[key], seen)
+  return raw
+}, {})

--- a/packages/histoire/src/client/app/util/state.ts
+++ b/packages/histoire/src/client/app/util/state.ts
@@ -2,10 +2,15 @@ import { unref, isRef } from 'vue'
 
 const isObject = (val) => val !== null && typeof val === 'object'
 
-export function toRawDeep (val, seen = new Set()) {
+export function toRawDeep(val, seen = new Set()) {
   const unwrappedValue = isRef(val) ? unref(val) : val
+  const valueType = typeof unwrappedValue
 
-  if (typeof unwrappedValue === 'symbol') {
+  if (valueType === 'symbol') {
+    return unwrappedValue.toString()
+  }
+
+  if (valueType === 'function') {
     return unwrappedValue.toString()
   }
 
@@ -20,13 +25,16 @@ export function toRawDeep (val, seen = new Set()) {
   seen.add(unwrappedValue)
 
   if (Array.isArray(unwrappedValue)) {
-    return unwrappedValue.map(value => toRawDeep(value, seen))
+    return unwrappedValue
+      .map((value) => toRawDeep(value, seen))
+      .filter((val) => val !== void 0)
   }
 
   return toRawObject(unwrappedValue, seen)
 }
 
-const toRawObject = (obj: Record<any, any>, seen = new Set()) => Object.keys(obj).reduce((raw, key) => {
-  raw[key] = toRawDeep(obj[key], seen)
-  return raw
-}, {})
+const toRawObject = (obj: Record<any, any>, seen = new Set()) =>
+  Object.keys(obj).reduce((raw, key) => {
+    raw[key] = toRawDeep(obj[key], seen)
+    return raw
+  }, {})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The state watcher in `packages/histoire/src/client/app/sandbox.ts` uses `toRawDeep` to send the story state to the app using `Window.postMessage()`. If the state contains a function, `Window.postMessage()` fails with the error `"DOMException: Failed to execute 'postMessage' on 'Window': () => alert("example") could not be cloned."` and the sandbox in the app doesn't show the component.

This PR fixes the issue by stringifying functions within `toRawDeep`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

