### PR TITLE
feat: added radio controls

### DIFF
--- a/examples/vue3/src/components/Controls.story.vue
+++ b/examples/vue3/src/components/Controls.story.vue
@@ -5,6 +5,12 @@ const options = {
   'ghost-of-tsushima': 'Ghost of Tsushima',
 }
 
+const radioOptions = {
+  'death-stranding': 'Death Stranding',
+  'metal-gear': 'Metal Gear',
+  'elden-ring': 'Elden Ring',
+}
+
 function initState () {
   return {
     text: 'Hello',
@@ -12,6 +18,7 @@ function initState () {
     number: 20,
     longText: 'Longer text...',
     select: 'crash-bandicoot',
+    radio: 'metal-gear',
   }
 }
 </script>
@@ -54,6 +61,11 @@ function initState () {
           v-model="state.select"
           title="HstSelect"
           :options="options"
+        />
+        <HstRadio
+          v-model="state.radio"
+          title="HstRadio"
+          :options="radioOptions"
         />
       </template>
     </Variant>

--- a/packages/histoire-controls/src/components/checkbox/HstCheckbox.vue
+++ b/packages/histoire-controls/src/components/checkbox/HstCheckbox.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits({
-  'update:modelValue': (_newValue: boolean) => true,
+  'update:modelValue': (newValue: boolean) => true,
 })
 
 function toggle () {

--- a/packages/histoire-controls/src/components/checkbox/HstCheckbox.vue
+++ b/packages/histoire-controls/src/components/checkbox/HstCheckbox.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits({
-  'update:modelValue': (newValue: boolean) => true,
+  'update:modelValue': (_newValue: boolean) => true,
 })
 
 function toggle () {
@@ -28,9 +28,11 @@ const path = ref<SVGPathElement>()
 const dasharray = ref(0)
 const progress = computed(() => props.modelValue ? 1 : 0)
 const dashoffset = computed(() => (1 - progress.value) * dasharray.value)
+
+// animationEnabled prevents the animation from triggering on mounted
 const animationEnabled = ref(false)
 
-watch(path, value => {
+watch(path, () => {
   dasharray.value = path.value.getTotalLength?.() ?? 21.21
 })
 </script>

--- a/packages/histoire-controls/src/components/radio/HstRadio.story.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.story.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import HstRadio from './HstRadio.vue'
+
+const options = {
+  'crash-bandicoot': 'Crash Bandicoot',
+  'the-last-of-us': 'The Last of Us',
+  'ghost-of-tsushima': 'Ghost of Tsushima',
+}
+
+const flatOptions = Object.keys(options)
+
+const objectOptions = Object.keys(options).map(key => ({
+  label: options[key],
+  value: key,
+}))
+
+function initState () {
+  return {
+    character: flatOptions[0],
+  }
+}
+</script>
+
+<template>
+  <Story title="HstRadio">
+    <Variant
+      title="playground"
+      :init-state="initState"
+    >
+      <template #default="{ state }">
+        <HstRadio
+          v-model="state.character"
+          title="Label"
+          :options="objectOptions"
+        />
+      </template>
+
+      <template #controls="{ state }">
+        <HstRadio
+          v-model="state.character"
+          title="Label"
+          :options="objectOptions"
+        />
+      </template>
+    </Variant>
+  </Story>
+</template>

--- a/packages/histoire-controls/src/components/radio/HstRadio.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.vue
@@ -1,0 +1,107 @@
+<script lang="ts">
+export default {
+  name: 'HstRadio',
+}
+</script>
+
+<script lang="ts" setup>
+import { computed, ComputedRef, ref } from 'vue'
+import HstWrapper from '../HstWrapper.vue'
+
+export interface RadioOption {
+  label: string
+  value: string
+}
+
+const props = defineProps<{
+  title?: string
+  modelValue: string
+  options: RadioOption[]
+}>()
+
+const formattedOptions: ComputedRef<Record<string, string>> = computed(() => {
+  if (Array.isArray(props.options)) {
+    return Object.fromEntries(props.options.map((value: string | RadioOption) => {
+      if (typeof value === 'string') {
+        return [value, value]
+      } else {
+        return [value.value, value.label]
+      }
+    }))
+  }
+  return props.options
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+const input = ref<HTMLInputElement>()
+
+function selectOption (value: string) {
+  emit('update:modelValue', value)
+  animationEnabled.value = true
+}
+
+// SVG check
+const animationEnabled = ref(false)
+</script>
+
+<template>
+  <HstWrapper
+    role="group"
+    :title="title"
+    class="htw-cursor-text htw-items-center"
+    :class="$attrs.class"
+    :style="$attrs.style"
+  >
+    <template
+      v-for="( label, value ) in formattedOptions"
+      :key="value"
+    >
+      <input
+        :id="`${value}-radio`"
+        type="radio"
+        :name="`${value}-radio`"
+        :value="value"
+        :checked="value === modelValue"
+        class="htw-hidden"
+        @change="selectOption(value)"
+      >
+      <label
+        tabindex="0"
+        :for="`${value}-radio`"
+        class="htw-cursor-pointer htw-flex htw-items-center htw-relative htw-p-2"
+        @keydown.enter.prevent="selectOption(value)"
+        @keydown.space.prevent="selectOption(value)"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          class="htw-relative htw-z-10 htw-border htw-border-solid group-active:htw-bg-gray-500/20 htw-text-inherit htw-rounded-full htw-box-border htw-inset-0 htw-transition-border htw-duration-150 htw-ease-out htw-mr-2"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="8"
+            :class="[
+              animationEnabled ? 'htw-transition-all' : 'htw-transition-none',
+              {
+                'htw-delay-150': modelValue === value,
+              },
+              modelValue === value
+                ? 'htw-fill-primary-500'
+                : 'htw-fill-transparent',
+            ]"
+          />
+        </svg>
+        {{ label }}
+      </label>
+    </template>
+
+    <template #actions>
+      <slot name="actions" />
+    </template>
+  </HstWrapper>
+</template>

--- a/packages/histoire-controls/src/components/radio/HstRadio.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.vue
@@ -67,7 +67,7 @@ const animationEnabled = ref(false)
       <label
         tabindex="0"
         :for="`${value}-radio`"
-        class="htw-cursor-pointer htw-flex htw-items-center htw-relative htw-p-2"
+        class="htw-cursor-pointer htw-flex htw-items-center htw-relative htw-py-2"
         @keydown.enter.prevent="selectOption(value)"
         @keydown.space.prevent="selectOption(value)"
       >
@@ -75,7 +75,12 @@ const animationEnabled = ref(false)
           width="16"
           height="16"
           viewBox="0 0 24 24"
-          class="htw-relative htw-z-10 htw-border htw-border-solid group-active:htw-bg-gray-500/20 htw-text-inherit htw-rounded-full htw-box-border htw-inset-0 htw-transition-border htw-duration-150 htw-ease-out htw-mr-2"
+          class="htw-relative htw-z-10 htw-border htw-border-solid  htw-text-inherit htw-rounded-full htw-box-border htw-inset-0 htw-transition-border htw-duration-150 htw-ease-out htw-mr-2"
+          :class="[
+            modelValue === value
+              ? 'htw-border-primary-500 htw-border-2'
+              : 'htw-border-black/25 dark:htw-border-white/25 htw-delay-150',
+          ]"
         >
           <circle
             cx="12"

--- a/packages/histoire-controls/src/components/radio/HstRadio.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.vue
@@ -39,7 +39,7 @@ function selectOption (value: string) {
   animationEnabled.value = true
 }
 
-// SVG check
+// animationEnabled prevents the animation from triggering on mounted
 const animationEnabled = ref(false)
 </script>
 

--- a/packages/histoire-controls/src/components/radio/HstRadio.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.vue
@@ -47,59 +47,60 @@ const animationEnabled = ref(false)
   <HstWrapper
     role="group"
     :title="title"
-    class="htw-cursor-text htw-items-center"
+    class="htw-cursor-text"
     :class="$attrs.class"
     :style="$attrs.style"
   >
-    <template
-      v-for="( label, value ) in formattedOptions"
-      :key="value"
-    >
-      <input
-        :id="`${value}-radio`"
-        type="radio"
-        :name="`${value}-radio`"
-        :value="value"
-        :checked="value === modelValue"
-        class="htw-hidden"
-        @change="selectOption(value)"
+    <div class="-htw-my-1">
+      <template
+        v-for="( label, value ) in formattedOptions"
+        :key="value"
       >
-      <label
-        tabindex="0"
-        :for="`${value}-radio`"
-        class="htw-cursor-pointer htw-flex htw-items-center htw-relative htw-py-2"
-        @keydown.enter.prevent="selectOption(value)"
-        @keydown.space.prevent="selectOption(value)"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          class="htw-relative htw-z-10 htw-border htw-border-solid  htw-text-inherit htw-rounded-full htw-box-border htw-inset-0 htw-transition-border htw-duration-150 htw-ease-out htw-mr-2"
-          :class="[
-            modelValue === value
-              ? 'htw-border-primary-500 htw-border-2'
-              : 'htw-border-black/25 dark:htw-border-white/25 htw-delay-150',
-          ]"
+        <input
+          :id="`${value}-radio`"
+          type="radio"
+          :name="`${value}-radio`"
+          :value="value"
+          :checked="value === modelValue"
+          class="htw-hidden"
+          @change="selectOption(value)"
         >
-          <circle
-            cx="12"
-            cy="12"
-            r="8"
+        <label
+          tabindex="0"
+          :for="`${value}-radio`"
+          class="htw-cursor-pointer htw-flex htw-items-center htw-relative htw-py-1 htw-group"
+          @keydown.enter.prevent="selectOption(value)"
+          @keydown.space.prevent="selectOption(value)"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="-12 -12 24 24"
+            class="htw-relative htw-z-10 htw-border htw-border-solid  htw-text-inherit htw-rounded-full htw-box-border htw-inset-0 htw-transition-border htw-duration-150 htw-ease-out htw-mr-2 group-hover:htw-border-primary-500"
             :class="[
-              animationEnabled ? 'htw-transition-all' : 'htw-transition-none',
-              {
-                'htw-delay-150': modelValue === value,
-              },
               modelValue === value
-                ? 'htw-fill-primary-500'
-                : 'htw-fill-transparent',
+                ? 'htw-border-primary-500'
+                : 'htw-border-black/25 dark:htw-border-white/25',
             ]"
-          />
-        </svg>
-        {{ label }}
-      </label>
-    </template>
+          >
+            <circle
+              r="7"
+              class="htw-will-change-transform"
+              :class="[
+                animationEnabled ? 'htw-transition-all' : 'htw-transition-none',
+                {
+                  'htw-delay-150': modelValue === value,
+                },
+                modelValue === value
+                  ? 'htw-fill-primary-500'
+                  : 'htw-fill-transparent htw-scale-0',
+              ]"
+            />
+          </svg>
+          {{ label }}
+        </label>
+      </template>
+    </div>
 
     <template #actions>
       <slot name="actions" />

--- a/packages/histoire-controls/src/components/radio/HstRadio.vue
+++ b/packages/histoire-controls/src/components/radio/HstRadio.vue
@@ -7,21 +7,17 @@ export default {
 <script lang="ts" setup>
 import { computed, ComputedRef, ref } from 'vue'
 import HstWrapper from '../HstWrapper.vue'
-
-export interface RadioOption {
-  label: string
-  value: string
-}
+import { HstControlOption } from '../../types'
 
 const props = defineProps<{
   title?: string
   modelValue: string
-  options: RadioOption[]
+  options: HstControlOption[]
 }>()
 
 const formattedOptions: ComputedRef<Record<string, string>> = computed(() => {
   if (Array.isArray(props.options)) {
-    return Object.fromEntries(props.options.map((value: string | RadioOption) => {
+    return Object.fromEntries(props.options.map((value: string | HstControlOption) => {
       if (typeof value === 'string') {
         return [value, value]
       } else {

--- a/packages/histoire-controls/src/components/select/CustomSelect.vue
+++ b/packages/histoire-controls/src/components/select/CustomSelect.vue
@@ -8,15 +8,11 @@ export default {
 import { Dropdown as VDropdown } from 'floating-vue'
 import { computed, ComputedRef } from 'vue'
 import { Icon } from '@iconify/vue'
-
-export interface SelectOption {
-  label: string
-  value: string
-}
+import { HstControlOption } from '../../types'
 
 const props = defineProps<{
   modelValue: string
-  options: Record<string, string> | string[] | SelectOption[]
+  options: Record<string, string> | string[] | HstControlOption[]
 }>()
 
 const emits = defineEmits<{
@@ -25,7 +21,7 @@ const emits = defineEmits<{
 
 const formattedOptions: ComputedRef<Record<string, string>> = computed(() => {
   if (Array.isArray(props.options)) {
-    return Object.fromEntries(props.options.map((value: string | SelectOption) => {
+    return Object.fromEntries(props.options.map((value: string | HstControlOption) => {
       if (typeof value === 'string') {
         return [value, value]
       } else {

--- a/packages/histoire-controls/src/components/select/HstSelect.vue
+++ b/packages/histoire-controls/src/components/select/HstSelect.vue
@@ -2,8 +2,6 @@
 export default {
   name: 'HstSelect',
 }
-
-export type { SelectOption as HstSelectOption } from './CustomSelect.vue'
 </script>
 
 <script lang="ts" setup>

--- a/packages/histoire-controls/src/components/select/HstSelect.vue
+++ b/packages/histoire-controls/src/components/select/HstSelect.vue
@@ -7,21 +7,19 @@ export type { SelectOption as HstSelectOption } from './CustomSelect.vue'
 </script>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
 import HstWrapper from '../HstWrapper.vue'
-import CustomSelect, { SelectOption } from './CustomSelect.vue'
+import CustomSelect from './CustomSelect.vue'
+import { HstControlOption } from '../../types'
 
 defineProps<{
   title?: string
   modelValue: string
-  options: Record<string, string> | string[] | SelectOption[]
+  options: Record<string, string> | string[] | HstControlOption[]
 }>()
 
 const emits = defineEmits<{
   (e: 'update:modelValue', value: string): void
 }>()
-
-const select = ref<HTMLInputElement>()
 </script>
 
 <template>

--- a/packages/histoire-controls/src/components/select/HstSelect.vue
+++ b/packages/histoire-controls/src/components/select/HstSelect.vue
@@ -11,7 +11,7 @@ import { ref } from 'vue'
 import HstWrapper from '../HstWrapper.vue'
 import CustomSelect, { SelectOption } from './CustomSelect.vue'
 
-const props = defineProps<{
+defineProps<{
   title?: string
   modelValue: string
   options: Record<string, string> | string[] | SelectOption[]

--- a/packages/histoire-controls/src/index.ts
+++ b/packages/histoire-controls/src/index.ts
@@ -9,6 +9,7 @@ import HstColorShadesVue from './components/design-tokens/HstColorShades.vue'
 import HstTokenListVue from './components/design-tokens/HstTokenList.vue'
 import HstTokenGridVue from './components/design-tokens/HstTokenGrid.vue'
 import HstCopyIconVue from './components/HstCopyIcon.vue'
+import HstRadioVue from './components/radio/HstRadio.vue'
 
 export const HstCheckbox = HstCheckboxVue
 export const HstText = HstTextVue
@@ -19,6 +20,7 @@ export const HstColorShades = HstColorShadesVue
 export const HstTokenList = HstTokenListVue
 export const HstTokenGrid = HstTokenGridVue
 export const HstCopyIcon = HstCopyIconVue
+export const HstRadio = HstRadioVue
 
 export function registerVueComponents (app: App) {
   app.component('HstCheckbox', HstCheckboxVue)
@@ -30,4 +32,5 @@ export function registerVueComponents (app: App) {
   app.component('HstColorShades', HstColorShadesVue)
   app.component('HstTokenList', HstTokenListVue)
   app.component('HstTokenGrid', HstTokenGridVue)
+  app.component('HstRadio', HstRadioVue)
 }

--- a/packages/histoire-controls/src/types.ts
+++ b/packages/histoire-controls/src/types.ts
@@ -1,0 +1,4 @@
+export interface HstControlOption {
+  label: string
+  value: string
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
As part of https://github.com/histoire-dev/histoire/issues/30 this PR adds a built-in select control <HstRadio />,

I added the possibility of passing the options as an array of objects { label: string, value: string} or as an array of values. Maybe an enhancement could be to pass a prop to define the key and the value, but I didn't want to complicate it. Both examples are available in the local story HstRadio.story.vue

I also added the control to the vue3 examples app

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
