### PR TITLE
docs: fix next link, fix #161

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -96,7 +96,7 @@ module.exports = {
           items: [
             {
               text: 'Why Histoire',
-              link: '/guide/index',
+              link: '/guide/',
             },
             {
               text: 'Getting Started',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix #161.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Having a quick look, VitePress seems to distinguish `/foo/` and `/foo/index` in terms of path definition.
As a result, `/foo/index` doesn't match meta data of the page corresponding to `/guide/index.md` file.

Another solution is setting it as `/guide/index.md` or `/guide/index.html`, but I believe trailing slash looks best, because other pages' `link` property is defined without file extensions (e.g. `/guide/getting-started`).

By the way, this is my very first contribution to Histoire. 👶 
Thank you for developing such an awesome tool. 🚀 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
