### PR TITLE
fix: support Vue shorthand prop type (#155)

### DIFF
--- a/packages/histoire-plugin-vue/src/client/app/SandboxVue3.vue
+++ b/packages/histoire-plugin-vue/src/client/app/SandboxVue3.vue
@@ -131,7 +131,7 @@ function scanForAutoProps (vnodes: any[]) {
         let types
         let defaultValue
         if (prop) {
-          const rawTypes = Array.isArray(prop.type) ? prop.type : [prop.type]
+          const rawTypes = Array.isArray(prop.type) ? prop.type : typeof prop === 'function' ? [prop] : [prop.type]
           types = rawTypes.map(t => {
             switch (t) {
               case String:


### PR DESCRIPTION
### Description

Vue auto props didn't support the shorthand prop syntax and failed to extract prop types:
```js
const props = defineProps({
  title: String
})
```

Reproduction: https://stackblitz.com/edit/node-q7tqea?file=src/components/Foo.story.vue

### Additional info

Not sure, if it needs additional tests, because current tests don't seem to cover auto prop typing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
