### PR TITLE
fix: resize story responsive preview

### DIFF
--- a/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
+++ b/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
@@ -37,7 +37,7 @@ function useDragger (el: Ref<HTMLDivElement>, value: Ref<number>, min: number, m
     event.preventDefault()
     event.stopPropagation()
     const start = axis === 'x' ? event.clientX : event.clientY
-    const startValue = value.value
+    const startValue = value.value ?? (axis === 'x' ? previewWrapper.value.clientWidth - 67 : previewWrapper.value.clientHeight - 70)
     resizing.value = true
 
     const removeListeners = [
@@ -46,12 +46,12 @@ function useDragger (el: Ref<HTMLDivElement>, value: Ref<number>, min: number, m
     ]
 
     function onMouseMove (event: MouseEvent) {
-      const snapTarget = (axis === 'x' ? previewWrapper.value.clientWidth - 67 : previewWrapper.value.clientHeight - 70)
+      const snapTarget = (axis === 'x' ? previewWrapper.value.clientWidth : previewWrapper.value.clientHeight)
       const delta = (axis === 'x' ? event.clientX : event.clientY) - start
       value.value = Math.max(min, Math.min(max, startValue + delta))
 
-      if (Math.abs(value.value - (snapTarget)) < 16) {
-        value.value = snapTarget
+      if (Math.abs(value.value - (snapTarget - 67)) < 16) {
+        value.value = null
       }
     }
 

--- a/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
+++ b/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
@@ -46,12 +46,12 @@ function useDragger (el: Ref<HTMLDivElement>, value: Ref<number>, min: number, m
     ]
 
     function onMouseMove (event: MouseEvent) {
-      const snapTarget = (axis === 'x' ? previewWrapper.value.clientWidth : previewWrapper.value.clientHeight)
+      const snapTarget = (axis === 'x' ? previewWrapper.value.clientWidth - 67 : previewWrapper.value.clientHeight - 70)
       const delta = (axis === 'x' ? event.clientX : event.clientY) - start
       value.value = Math.max(min, Math.min(max, startValue + delta))
 
-      if (Math.abs(value.value - (snapTarget - 67)) < 16) {
-        value.value = null
+      if (Math.abs(value.value - (snapTarget)) < 16) {
+        value.value = snapTarget
       }
     }
 


### PR DESCRIPTION
### Description

When the responsive preview is at 'Auto' width and height, if we try to resize again, the preview immediately snaps to minimum width or height. After the snap `value.value` becomes `null`. During the next resize, the `startValue` takes up this `null`. I guess this is why it is happening.

Now when the snap happens, the resize placeholder shows 'Auto'. And in the next resize, the `startValue` is taken with respect to the current width/height.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
