### PR TITLE
Added questionmark to possibly undefined userViteConfig

### DIFF
--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -65,7 +65,7 @@ export async function getViteConfigWithPlugins (isServer: boolean, ctx: Context)
 
   const userViteConfig = await loadViteConfigFromFile({ command: ctx.mode === 'dev' ? 'serve' : 'build', mode: ctx.mode })
 
-  const inlineConfig = await mergeHistoireViteConfig(userViteConfig.config ?? {}, ctx)
+  const inlineConfig = await mergeHistoireViteConfig(userViteConfig?.config ?? {}, ctx)
   const plugins: VitePlugin[] = []
 
   plugins.push({


### PR DESCRIPTION
Tried to run histoire with nuxt3 and got that error.

![pull](https://user-images.githubusercontent.com/79873939/180444048-958288ff-3089-40a9-a954-9bf9410c850f.png)

Questionmark after userViteConfig solves the problem and histoire runs fine.
