### PR TITLE
chore: fix vendors windows build

### DIFF
--- a/packages/histoire-vendors/rollup.config.mjs
+++ b/packages/histoire-vendors/rollup.config.mjs
@@ -65,9 +65,10 @@ export default defineConfig({
             }
             // Create entry files in root
             {
-              const content = `import Default from './${path.relative(__dirname, file).replace(/\.d\.ts$/, '')}'
+              const filepath = path.relative(__dirname, file).replace(/\.d\.ts$/, '').replace(/\\/g, '/')
+              const content = `import Default from './${filepath}'
 export default Default
-export * from './${path.relative(__dirname, file).replace(/\.d\.ts$/, '')}'\n`
+export * from './${filepath}'\n`
               fs.writeFileSync(path.basename(file).replace(/^b-/, ''), content, 'utf-8')
             }
             // Exports (package.json)

--- a/packages/histoire-vendors/rollup.config.mjs
+++ b/packages/histoire-vendors/rollup.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig({
             dependencies: {},
           }
           const pkgExports = {}
-          const files = globbySync('./dist/client/*.d.ts')
+          const files = globbySync('./dist/client/*.d.ts', { cwd: __dirname })
           for (const file of files) {
             // Retrieve imports from dts
             {
@@ -65,10 +65,10 @@ export default defineConfig({
             }
             // Create entry files in root
             {
-              const filepath = path.relative(__dirname, file).replace(/\.d\.ts$/, '').replace(/\\/g, '/')
-              const content = `import Default from './${filepath}'
+              const filepath = file.replace(/\.d\.ts$/, '')
+              const content = `import Default from '${filepath}'
 export default Default
-export * from './${filepath}'\n`
+export * from '${filepath}'\n`
               fs.writeFileSync(path.basename(file).replace(/^b-/, ''), content, 'utf-8')
             }
             // Exports (package.json)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Building `@histoire/vendors` on windows was generating invalid outputs.

**Before**
```ts
import Default from './dist\client\b-pinia'
export default Default
export * from './dist\client\b-pinia'
```
**After**
```ts
import Default from './dist/client/b-pinia'
export default Default
export * from './dist/client/b-pinia'
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
