### PR TITLE
fix: resolve plugin correctly on windows

### DIFF
--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -265,18 +265,18 @@ if (import.meta.hot) {
       }
 
       if (id === RESOLVED_SUPPORT_PLUGINS_CLIENT) {
-        const plugins = ctx.supportPlugins.map(p => `'${p.id}': () => import('${require.resolve(`${p.moduleName}/client`, {
+        const plugins = ctx.supportPlugins.map(p => `'${p.id}': () => import(${JSON.stringify(require.resolve(`${p.moduleName}/client`, {
           paths: [ctx.root, import.meta.url],
-        })}')`)
+        }))})`)
         return `export const clientSupportPlugins = {
           ${plugins.join(',\n  ')}
         }`
       }
 
       if (id === RESOLVED_SUPPORT_PLUGINS_COLLECT) {
-        const plugins = ctx.supportPlugins.map(p => `'${p.id}': () => import('${require.resolve(`${p.moduleName}/collect`, {
+        const plugins = ctx.supportPlugins.map(p => `'${p.id}': () => import(${JSON.stringify(require.resolve(`${p.moduleName}/collect`, {
           paths: [ctx.root, import.meta.url],
-        })}')`)
+        }))})`)
         return `export const collectSupportPlugins = {
           ${plugins.join(',\n  ')}
         }`


### PR DESCRIPTION
### Description

When running histoire on Windows the following error happens:
```
[plugin:vite:import-analysis] Failed to resolve import "D:documentsGitHubhistoirepackageshistoire-plugin-vuedistundledclientclient.js" from "virtual:$histoire-support-plugins-client". Does the file exist?
1  |  export const clientSupportPlugins = {
2  |            'vue3': () => import('D:\documents\GitHub\histoire\packages\histoire-plugin-vue\dist\bundled\client\client.js')
   |                                 ^
3  |          }
```

This was happening because `\` was not escaped when quoting with `'`.
This PR uses `JSON.stringify(foo)` instead of `"'" + foo + "'"`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
