### PR TITLE
fix: do not add target blank to urls that start with # in markdown

### DIFF
--- a/examples/vue3/cypress/integration/markdown-links.js
+++ b/examples/vue3/cypress/integration/markdown-links.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+
+describe('Markdown links', () => {
+  it('should be just #welcome and not contain attribute target="_blank"', () => {
+    cy.visit('/story/src-components-markdownlinks-story-vue?variantId=_default')
+    cy.get('#link-to-welcome').should('have.attr', 'href', '#welcome').should('not.have.attr', 'target')
+  })
+
+  it('should have target="_blank" set when they external', () => {
+    cy.visit('/story/src-components-markdownlinks-story-vue?variantId=_default')
+    cy.get('#link-to-history').should('have.attr', 'href', 'https://histoire.dev/').should('have.attr', 'target', '_blank')
+  })
+})

--- a/examples/vue3/cypress/integration/search.js
+++ b/examples/vue3/cypress/integration/search.js
@@ -48,7 +48,7 @@ describe('Search', () => {
     cy.visit('/')
     cy.get('[data-test-id="search-btn"]').click()
     cy.get('[data-test-id="search-modal"] input').type('welcome')
-    cy.get('[data-test-id="search-item"]').should('have.length', 1)
+    cy.get('[data-test-id="search-item"]').should('have.length', 2)
     cy.get('[data-test-id="search-item"]').contains('Introduction')
   })
 })

--- a/examples/vue3/cypress/integration/stories-list.js
+++ b/examples/vue3/cypress/integration/stories-list.js
@@ -4,7 +4,7 @@ describe('Stories list', () => {
   it('should display the stories', () => {
     cy.clearLocalStorage()
     cy.visit('/')
-    cy.get('[data-test-id="story-list-item"]').should('have.length', 23)
+    cy.get('[data-test-id="story-list-item"]').should('have.length', 24)
     cy.get('[data-test-id="story-list-item"]').contains('🐱 Meow')
     cy.get('[data-test-id="story-list-item"]').contains('BaseButton')
       .contains('3') // Variants count

--- a/examples/vue3/src/components/MarkdownLinks.story.vue
+++ b/examples/vue3/src/components/MarkdownLinks.story.vue
@@ -1,0 +1,15 @@
+<template>
+  <Story
+    group="top"
+    docs-only
+    icon="carbon:bookmark"
+  />
+</template>
+
+<docs lang="md">
+[Link to welcome header](#welcome){id="link-to-welcome"}
+
+# Welcome
+
+This is just a link to [Histoire.dev](https://histoire.dev/){id="link-to-history"}.
+</docs>

--- a/packages/histoire/src/node/markdown.ts
+++ b/packages/histoire/src/node/markdown.ts
@@ -36,7 +36,7 @@ export async function createMarkdownRenderer () {
       const hrefIndex = tokens[idx].attrIndex('href')
       const classIndex = tokens[idx].attrIndex('class')
 
-      if (hrefIndex >= 0 && !tokens[idx].attrs[hrefIndex][1].startsWith('/') && (classIndex < 0 || !tokens[idx].attrs[classIndex][1].includes('header-anchor'))) {
+      if (hrefIndex >= 0 && !tokens[idx].attrs[hrefIndex][1].startsWith('/') && !tokens[idx].attrs[hrefIndex][1].startsWith('#') && (classIndex < 0 || !tokens[idx].attrs[classIndex][1].includes('header-anchor'))) {
         // If you are sure other plugins can't add `target` - drop check below
         const aIndex = tokens[idx].attrIndex('target')
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently it is not possible to add  internal links starting with `#` as those get `target=_blank` added.

### Additional context

#234 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
