### PR TITLE
docs: fix the variables in the svelte section (fix histoire-dev#242)

### DIFF
--- a/docs/guide/svelte3/controls.md
+++ b/docs/guide/svelte3/controls.md
@@ -23,7 +23,7 @@ The first step is to define the state that will be shared to your story. Histoir
       {content}
     </MyButton>
 
-    <input bind:value={message}>
+    <input bind:value={text}>
   </Hst.Variant>
 </Hst.Story>
 ```


### PR DESCRIPTION
### Description

Fix #242 

### Additional context

Just variable naming in [this link](https://histoire.dev/guide/svelte3/controls.html#defining-state). I've considered conserving the variable `text`. But if you prefer `message`, feel free to reject this PR or to ask me to change it. 😁

---

### What is the purpose of this pull request? To avoid someone dropping the docs because doesn't figure out the reason for the error in his/her console.

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
