### PR TITLE
fix: missing dark class when layout.iframe option is false

### DIFF
--- a/packages/histoire-app/src/app/components/story/StoryVariantSinglePreviewNative.vue
+++ b/packages/histoire-app/src/app/components/story/StoryVariantSinglePreviewNative.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import GenericRenderStory from './GenericRenderStory.vue'
 import type { Story, Variant } from '../../types'
+import { isDark } from '../../util/dark'
+import { histoireConfig } from '../../util/config'
 import StoryResponsivePreview from './StoryResponsivePreview.vue'
 
 const props = defineProps<{
@@ -37,6 +39,7 @@ function onReady () {
         :variant="variant"
         :story="story"
         class="htw-h-full"
+        :class="[ isDark ? histoireConfig.sandboxDarkClass : undefined ]"
         @ready="onReady"
       />
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- You too! Histoire is so good. -->
### Description
I found that dark class is not attached when `layout.iframe` option of Story component is false.
This PR fix it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

You can check it on the following stackblitz repo. 
https://stackblitz.com/edit/histoire-vue3-starter-nbze5i?file=src%2FBaseButton.vue

**Step to reproduce**
1. Select the `BaseButton`.
2. Toggle dark mode, then the style of it is not changed. It's expected to change to a dark mode style, just like when iframe is used.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
