### PR TITLE
fix(svelte): variantState should not be modified by component internal state

### DIFF
--- a/packages/histoire-plugin-svelte/src/client/util.ts
+++ b/packages/histoire-plugin-svelte/src/client/util.ts
@@ -1,5 +1,5 @@
 import { watch as _watch } from '@histoire/vendors/vue'
-import { applyState } from '@histoire/shared'
+import { applyState, clone } from '@histoire/shared'
 
 function cleanupState (state: Record<string, any>): Record<string, any> {
   const result = {}
@@ -32,7 +32,7 @@ export function syncState (variantState, onChange: (state) => unknown) {
     if (value == null) return
     if (!syncing) {
       syncing = true
-      applyState(variantState, cleanupState(value))
+      applyState(variantState, clone(cleanupState(value)))
     } else {
       syncing = false
     }


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

fix #264 

Since `Vue.watch` will use `Proxy` to wrapper svelte component state value, once component state value changed, the global `variantState` changed in the same time which will make `applyState` useless and the `watch` callback not be triggered.

We can use `histoire/shared.clone` to cut the relation between `variantState` and component internal state.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
