### PR TITLE
fix: config dev port (fix #317)

### DIFF
--- a/packages/histoire/src/node/commands/dev.ts
+++ b/packages/histoire/src/node/commands/dev.ts
@@ -15,7 +15,7 @@ export async function devCommand (options: DevOptions) {
     const ctx = await createContext({
       mode: 'dev',
     })
-    const { server, close } = await createServer(ctx, options.port ?? 6006)
+    const { server, close } = await createServer(ctx, { port: options.port })
     server.printUrls()
 
     // Histoire config watcher

--- a/packages/histoire/src/node/server.ts
+++ b/packages/histoire/src/node/server.ts
@@ -9,7 +9,7 @@ import { useModuleLoader } from './load.js'
 import { wrapLogError } from './util/log.js'
 import { createMarkdownFilesWatcher, onMarkdownListChange } from './markdown.js'
 
-export async function createServer (ctx: Context, port: number) {
+export async function createServer (ctx: Context, config: {port?: number} = {}) {
   const server = await createViteServer(await getViteConfigWithPlugins(false, ctx))
   await server.pluginContainer.buildStart({})
 
@@ -36,7 +36,7 @@ export async function createServer (ctx: Context, port: number) {
   }
 
   // Wait for pre-bundling (in `listen()`)
-  await server.listen(port)
+  await server.listen(config.port ?? server.config.server?.port ?? 6006)
 
   const {
     clearCache,

--- a/packages/histoire/src/node/server.ts
+++ b/packages/histoire/src/node/server.ts
@@ -40,7 +40,7 @@ export async function createServer (ctx: Context, options: CreateServerOptions =
   }
 
   // Wait for pre-bundling (in `listen()`)
-  await server.listen(options.port ?? server.config.server?.port ?? 6006)
+  await server.listen(options.port ?? server.config.server?.port)
 
   const {
     clearCache,

--- a/packages/histoire/src/node/server.ts
+++ b/packages/histoire/src/node/server.ts
@@ -9,7 +9,11 @@ import { useModuleLoader } from './load.js'
 import { wrapLogError } from './util/log.js'
 import { createMarkdownFilesWatcher, onMarkdownListChange } from './markdown.js'
 
-export async function createServer (ctx: Context, config: {port?: number} = {}) {
+export interface CreateServerOptions {
+  port?: number
+}
+
+export async function createServer (ctx: Context, options: CreateServerOptions = {}) {
   const server = await createViteServer(await getViteConfigWithPlugins(false, ctx))
   await server.pluginContainer.buildStart({})
 
@@ -36,7 +40,7 @@ export async function createServer (ctx: Context, config: {port?: number} = {}) 
   }
 
   // Wait for pre-bundling (in `listen()`)
-  await server.listen(config.port ?? server.config.server?.port ?? 6006)
+  await server.listen(options.port ?? server.config.server?.port ?? 6006)
 
   const {
     clearCache,

--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -106,7 +106,7 @@ export async function getViteConfigWithPlugins (isServer: boolean, ctx: Context)
   const resolvedViteConfig = await resolveViteConfig(ctx)
 
   const userViteConfigFile = await loadViteConfigFromFile({ command: ctx.mode === 'dev' ? 'serve' : 'build', mode: ctx.mode })
-  const userViteConfig = mergeViteConfig(userViteConfigFile.config ?? {}, { server: { port: 6006 } })
+  const userViteConfig = mergeViteConfig(userViteConfigFile?.config ?? {}, { server: { port: 6006 } })
 
   const inlineConfig = await mergeHistoireViteConfig(userViteConfig, ctx)
   const plugins: VitePlugin[] = []

--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -105,9 +105,10 @@ async function mergeHistoireViteConfig (viteConfig: InlineConfig, ctx: Context) 
 export async function getViteConfigWithPlugins (isServer: boolean, ctx: Context): Promise<InlineConfig> {
   const resolvedViteConfig = await resolveViteConfig(ctx)
 
-  const userViteConfig = await loadViteConfigFromFile({ command: ctx.mode === 'dev' ? 'serve' : 'build', mode: ctx.mode })
+  const userViteConfigFile = await loadViteConfigFromFile({ command: ctx.mode === 'dev' ? 'serve' : 'build', mode: ctx.mode })
+  const userViteConfig = mergeViteConfig(userViteConfigFile.config ?? {}, { server: { port: 6006 } })
 
-  const inlineConfig = await mergeHistoireViteConfig(userViteConfig?.config ?? {}, ctx)
+  const inlineConfig = await mergeHistoireViteConfig(userViteConfig, ctx)
   const plugins: VitePlugin[] = []
 
   const hasPnpm = !!(await findUp(ctx.root, ['pnpm-lock.yaml']))


### PR DESCRIPTION
### Description

Dev port was always 6006 when not defined in the command line

### Additional context

Example histoire config:

```ts
// vite.config.js
/// <reference types="histoire" />

import { defineConfig } from 'vite'

export default defineConfig({
  // ...
  histoire: {
    vite: {
      server: {
        port: 1980,
      },
    },
  },
})

```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
