### PR TITLE
fix: missing types components in global components

### DIFF
--- a/packages/histoire-controls/src/components/button/HstButtonGroup.vue
+++ b/packages/histoire-controls/src/components/button/HstButtonGroup.vue
@@ -13,7 +13,7 @@ import HstButton from './HstButton.vue'
 const props = defineProps<{
   title?: string
   modelValue: string
-  options: HstControlOption[]
+  options: string[] | HstControlOption[]
 }>()
 
 const formattedOptions: ComputedRef<Record<string, string>> = computed(() => {

--- a/packages/histoire-controls/src/components/checkbox/HstCheckboxList.vue
+++ b/packages/histoire-controls/src/components/checkbox/HstCheckboxList.vue
@@ -13,7 +13,7 @@ import HstSimpleCheckbox from './HstSimpleCheckbox.vue'
 const props = defineProps<{
   title?: string
   modelValue: Array<string>
-  options: HstControlOption[]
+  options: string[] | HstControlOption[]
 }>()
 
 const formattedOptions: ComputedRef<Record<string, string>> = computed(() => {

--- a/packages/histoire-plugin-vue/components.d.ts
+++ b/packages/histoire-plugin-vue/components.d.ts
@@ -13,6 +13,12 @@ import type {
   HstTokenGrid,
   HstTokenList,
   HstColorShades,
+  HstSelect,
+  HstButton,
+  HstButtonGroup,
+  HstCheckboxList,
+  HstJson,
+  HstSlider,
 } from '@histoire/controls'
 
 // Utils
@@ -139,5 +145,11 @@ declare module '@vue/runtime-core' {
     HstTokenGrid: typeof HstTokenGrid
     HstTokenList: typeof HstTokenList
     HstColorShades: typeof HstColorShades
+    HstSelect: typeof HstSelect
+    HstButton: typeof HstButton
+    HstButtonGroup: typeof HstButtonGroup
+    HstCheckboxList: typeof HstCheckboxList
+    HstJson: typeof HstJson
+    HstSlider: typeof HstSlider
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Add types components in global components
Add type string[] in HstButtonGroup, HstCheckboxList

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
