### PR TITLE
docs: remove reference to plugin that no longer exists

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -373,7 +373,7 @@ List of Vite plugin names to exclude for Histoire.
 ```ts
 export default defineConfig({
   viteIgnorePlugins: [
-    'vite-plugin-svelte-kit',
+    'vite-plugin-example',
   ],
 })
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There's no longer a plugin named `vite-plugin-svelte-kit`. Also, users should not need to set this to use SvelteKit with Histoire so I just changed it to a generic example.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
