### PR TITLE
fix(svelte-control-elements): textarea capitalization typo on interface

### DIFF
--- a/packages/histoire-plugin-svelte/src/index.ts
+++ b/packages/histoire-plugin-svelte/src/index.ts
@@ -86,7 +86,7 @@ export interface Hst {
     min: number
     max: number
   }>
-  TextArea: typeof SvelteComponentTyped<{
+  Textarea: typeof SvelteComponentTyped<{
     value: string
     title: string
   }>


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`@histoire/plugin-svelte` seems to wrongfully use `TextArea` instead of `Textarea` on the exported `Hst` interface. ([Demo](https://stackblitz.com/edit/sveltejs-kit-template-default-g4v5ov))

### ~~Additional context~~

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] ~~New Feature~~
- [ ] ~~Documentation update~~
- [ ] ~~Other~~

### Before submitting the PR, please make sure you do the following

- [ ] ~~If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*~~
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] ~~Ideally, include relevant tests that fail without this PR but pass with it.~~
