### PR TITLE
docs(svelte): correct a typo in the svelte getting started docs

### DIFF
--- a/docs/guide/svelte3/getting-started.md
+++ b/docs/guide/svelte3/getting-started.md
@@ -61,7 +61,7 @@ export default defineConfig({
 
 ## Command Line Interface
 
-Histoire provides two commands:
+Histoire provides three commands:
 - `histoire dev`: starts a development server with hot-reload
 - `histoire build`: builds the app for production
 - `histoire preview`: starts an HTTP server that serves the built app


### PR DESCRIPTION
### Description

Fixed a simple typo in the Svelte getting started docs. 

> Histoire provides two commands:
> [3 commands]

I changed `two` to `three`

### Additional context

https://histoire.dev/guide/svelte3/getting-started.html

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
