### PR TITLE
feat: Dark mode API and config, fix #388 (#438

### DIFF
--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -23,3 +23,27 @@ if (!isCollecting()) {
   // do something only in the browser
 }
 ```
+
+## `isDark`
+
+Returns `true` if dark mode is enabled.
+
+```js
+import { isDark } from 'histoire/client'
+
+if (isDark()) {
+  // do something only in dark mode
+}
+```
+
+## `toggleDark`
+
+`toggleDark(value?: boolean): boolean`
+
+Toggles dark mode. If `value` is provided, it will be used instead of toggling. Returns the new value.
+
+```js
+import { toggleDark } from 'histoire/client'
+
+toggleDark(true)
+```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -110,6 +110,9 @@ Properties:
 - `favicon: string`: Href to the favicon file (**not** processed by Vite). Put the file in the `public` directory.
 - `colors: Object`: Customize the colors. Each color should be an object with shades as keys.
 - `logoHref: string`: Add a link to the main logo
+- `defaultColorScheme: 'light' | 'dark' | 'auto'`: Default color scheme for the app. `'auto'` will use the system preference.
+- `hideColorSchemeSwitch: boolean`: Hides the dark mode button in the toolbar.
+- `storeColorScheme: boolean`: Enable persistence of the color scheme in the browser's local storage.
 
 ```ts
 import { defaultColors } from 'histoire'
@@ -127,6 +130,9 @@ export default defineConfig({
       primary: defaultColors.cyan,
     },
     logoHref: 'https://acme.com',
+    defaultColorScheme: 'light',
+    hideColorSchemeSwitch: true,
+    storeColorScheme: false,
   },
 })
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^5.18.0",
     "@vue/eslint-config-standard": "^6.1.0",
     "@vue/eslint-config-typescript": "^10.0.0",
-    "@vueuse/core": "^8.2.5",
+    "@vueuse/core": "^9.12.0",
     "autoprefixer": "^10.4.4",
     "conventional-changelog-cli": "^2.2.2",
     "eslint": "^8.13.0",

--- a/packages/histoire-app/src/app/api.ts
+++ b/packages/histoire-app/src/app/api.ts
@@ -1,1 +1,9 @@
+import { isDark as _isDark } from './util/dark.js'
+
 export { logEvent } from './util/events.js'
+
+export { toggleDark } from './util/dark.js'
+
+export function isDark () {
+  return _isDark.value
+}

--- a/packages/histoire-app/src/app/components/app/AppHeader.vue
+++ b/packages/histoire-app/src/app/components/app/AppHeader.vue
@@ -50,6 +50,7 @@ onKeyboardShortcut(['ctrl+shift+d', 'meta+shift+d'], (event) => {
       </a>
 
       <a
+        v-if="!histoireConfig.theme.hideColorSchemeSwitch"
         v-tooltip="makeTooltip('Toggle dark mode', ({ isMac }) => isMac ? 'meta+shift+d' : 'ctrl+shift+d')"
         class="htw-p-2 sm:htw-p-1 hover:htw-text-primary-500 dark:hover:htw-text-primary-400 htw-cursor-pointer htw-text-gray-900 dark:htw-text-gray-100"
         @click="toggleDark()"

--- a/packages/histoire-app/src/app/util/dark.ts
+++ b/packages/histoire-app/src/app/util/dark.ts
@@ -1,7 +1,12 @@
 import { watch } from 'vue'
 import { useDark, useToggle } from '@vueuse/core'
+import { histoireConfig } from './config.js'
 
-export const isDark = useDark({ valueDark: 'htw-dark' })
+export const isDark = useDark({
+  valueDark: 'htw-dark',
+  initialValue: histoireConfig.theme.defaultColorScheme,
+  storageKey: histoireConfig.theme.storeColorScheme ? 'histoire-color-scheme' : null,
+})
 export const toggleDark = useToggle(isDark)
 
 function applyDarkToControls () {

--- a/packages/histoire-controls/package.json
+++ b/packages/histoire-controls/package.json
@@ -55,7 +55,7 @@
     "@types/node": "^17.0.32",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/test-utils": "^2.2.10",
-    "@vueuse/core": "^8.2.5",
+    "@vueuse/core": "^9.12.0",
     "autoprefixer": "^10.4.4",
     "concurrently": "^7.1.0",
     "floating-vue": "^2.0.0-beta.19",

--- a/packages/histoire-shared/src/types/config.ts
+++ b/packages/histoire-shared/src/types/config.ts
@@ -116,6 +116,10 @@ export interface HistoireConfig {
      * Add a link to the main logo
      */
     logoHref?: string
+    /**
+     * Default color scheme for the app.
+     */
+    defaultColorScheme?: 'light' | 'dark'
   }
   /**
    * Setup file exporting a default function executed when setting up each story preview.

--- a/packages/histoire-shared/src/types/config.ts
+++ b/packages/histoire-shared/src/types/config.ts
@@ -119,7 +119,15 @@ export interface HistoireConfig {
     /**
      * Default color scheme for the app.
      */
-    defaultColorScheme?: 'light' | 'dark'
+    defaultColorScheme?: 'light' | 'dark' | 'auto'
+    /**
+     * Hides the dark mode button in the toolbar.
+     */
+    hideColorSchemeSwitch?: boolean
+    /**
+     * Enable persistence of the color scheme in the browser.
+     */
+    storeColorScheme?: boolean
   }
   /**
    * Setup file exporting a default function executed when setting up each story preview.

--- a/packages/histoire-vendors/package.json
+++ b/packages/histoire-vendors/package.json
@@ -35,7 +35,7 @@
     "@rollup/plugin-commonjs": "^23.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@types/node": "^18.0.3",
-    "@vueuse/core": "^8.2.5",
+    "@vueuse/core": "^9.12.0",
     "execa": "^6.1.0",
     "floating-vue": "^2.0.0-beta.19",
     "fs-extra": "^10.0.1",

--- a/packages/histoire/client.d.ts
+++ b/packages/histoire/client.d.ts
@@ -14,3 +14,6 @@ export function logEvent (name: string, argument): void
  * Returns `true` when in the NodeJS server while collecting stories.
  */
 export function isCollecting (): boolean
+
+export function toggleDark (value?: boolean): boolean
+export function isDark (): boolean

--- a/packages/histoire/src/node/config.ts
+++ b/packages/histoire/src/node/config.ts
@@ -48,6 +48,8 @@ export function getDefaultConfig (): HistoireConfig {
         primary: defaultColors.emerald,
         gray: defaultColors.zinc,
       },
+      defaultColorScheme: 'auto',
+      storeColorScheme: true,
     },
     responsivePresets: [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
       '@typescript-eslint/parser': ^5.18.0
       '@vue/eslint-config-standard': ^6.1.0
       '@vue/eslint-config-typescript': ^10.0.0
-      '@vueuse/core': ^8.2.5
+      '@vueuse/core': ^9.12.0
       autoprefixer: ^10.4.4
       conventional-changelog-cli: ^2.2.2
       eslint: ^8.13.0
@@ -35,7 +35,7 @@ importers:
       '@typescript-eslint/parser': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
       '@vue/eslint-config-standard': 6.1.0_xjrppepy6gxqfolcwwwwmzi37e
       '@vue/eslint-config-typescript': 10.0.0_tf6rgb5i7kw5m4rbu3ajzgw7l4
-      '@vueuse/core': 8.9.4
+      '@vueuse/core': 9.12.0
       autoprefixer: 10.4.13_postcss@8.4.21
       conventional-changelog-cli: 2.2.2
       eslint: 8.33.0
@@ -393,7 +393,7 @@ importers:
       '@types/node': ^17.0.32
       '@vitejs/plugin-vue': ^4.0.0
       '@vue/test-utils': ^2.2.10
-      '@vueuse/core': ^8.2.5
+      '@vueuse/core': ^9.12.0
       autoprefixer: ^10.4.4
       concurrently: ^7.1.0
       floating-vue: ^2.0.0-beta.19
@@ -419,7 +419,7 @@ importers:
       '@types/node': 17.0.45
       '@vitejs/plugin-vue': 4.0.0_vite@4.1.1+vue@3.2.47
       '@vue/test-utils': 2.2.10_vue@3.2.47
-      '@vueuse/core': 8.9.4_vue@3.2.47
+      '@vueuse/core': 9.12.0_vue@3.2.47
       autoprefixer: 10.4.13_postcss@8.4.21
       concurrently: 7.6.0
       floating-vue: 2.0.0-beta.20_vue@3.2.47
@@ -615,7 +615,7 @@ importers:
       '@rollup/plugin-commonjs': ^23.0.3
       '@rollup/plugin-node-resolve': ^15.0.1
       '@types/node': ^18.0.3
-      '@vueuse/core': ^8.2.5
+      '@vueuse/core': ^9.12.0
       execa: ^6.1.0
       floating-vue: ^2.0.0-beta.19
       fs-extra: ^10.0.1
@@ -632,7 +632,7 @@ importers:
       '@rollup/plugin-commonjs': 23.0.7_rollup@3.14.0
       '@rollup/plugin-node-resolve': 15.0.1_rollup@3.14.0
       '@types/node': 18.11.19
-      '@vueuse/core': 8.9.4_vue@3.2.47
+      '@vueuse/core': 9.12.0_vue@3.2.47
       execa: 6.1.0
       floating-vue: 2.0.0-beta.20_vue@3.2.47
       fs-extra: 10.1.0
@@ -3164,10 +3164,6 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
-  /@types/web-bluetooth/0.0.14:
-    resolution: {integrity: sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==}
-    dev: true
-
   /@types/web-bluetooth/0.0.16:
     resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
     dev: true
@@ -3681,39 +3677,16 @@ packages:
       vue: 3.2.47
       vuetify: 3.1.3_5dw3rd5byqobayzjz2xjbzwmi4
 
-  /@vueuse/core/8.9.4:
-    resolution: {integrity: sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: '*'
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
+  /@vueuse/core/9.12.0:
+    resolution: {integrity: sha512-h/Di8Bvf6xRcvS/PvUVheiMYYz3U0tH3X25YxONSaAUBa841ayMwxkuzx/DGUMCW/wHWzD8tRy2zYmOC36r4sg==}
     dependencies:
-      '@types/web-bluetooth': 0.0.14
-      '@vueuse/metadata': 8.9.4
-      '@vueuse/shared': 8.9.4
+      '@types/web-bluetooth': 0.0.16
+      '@vueuse/metadata': 9.12.0
+      '@vueuse/shared': 9.12.0
       vue-demi: 0.13.11
-    dev: true
-
-  /@vueuse/core/8.9.4_vue@3.2.47:
-    resolution: {integrity: sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: '*'
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      '@types/web-bluetooth': 0.0.14
-      '@vueuse/metadata': 8.9.4
-      '@vueuse/shared': 8.9.4_vue@3.2.47
-      vue: 3.2.47
-      vue-demi: 0.13.11_vue@3.2.47
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
     dev: true
 
   /@vueuse/core/9.12.0_vue@3.2.47:
@@ -3743,41 +3716,17 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vueuse/metadata/8.9.4:
-    resolution: {integrity: sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw==}
-    dev: true
-
   /@vueuse/metadata/9.12.0:
     resolution: {integrity: sha512-9oJ9MM9lFLlmvxXUqsR1wLt1uF7EVbP5iYaHJYqk+G2PbMjY6EXvZeTjbdO89HgoF5cI6z49o2zT/jD9SVoNpQ==}
     dev: true
 
-  /@vueuse/shared/8.9.4:
-    resolution: {integrity: sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: '*'
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
+  /@vueuse/shared/9.12.0:
+    resolution: {integrity: sha512-TWuJLACQ0BVithVTRbex4Wf1a1VaRuSpVeyEd4vMUWl54PzlE0ciFUshKCXnlLuD0lxIaLK4Ypj3NXYzZh4+SQ==}
     dependencies:
       vue-demi: 0.13.11
-    dev: true
-
-  /@vueuse/shared/8.9.4_vue@3.2.47:
-    resolution: {integrity: sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: '*'
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      vue: 3.2.47
-      vue-demi: 0.13.11_vue@3.2.47
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
     dev: true
 
   /@vueuse/shared/9.12.0_vue@3.2.47:


### PR DESCRIPTION
Fix #388

New configuration options:

```js
export default defineConfig({
  theme: {
    defaultColorScheme: 'light',
    hideColorSchemeSwitch: true,
    storeColorScheme: false,
  },
})
```

New client API:

```js
import { isDark, toggleDark } from 'histoire/client'

if (isDark()) {
  // do something only in dark mode
}

toggleDark()
toggleDark(true)
```


