### PR TITLE
feat(screenshot): add launchOptionsArgs to be able to pass args for c…

### DIFF
--- a/packages/histoire-plugin-screenshot/README.md
+++ b/packages/histoire-plugin-screenshot/README.md
@@ -18,3 +18,25 @@ export default defineConfig({
   ],
 })
 ```
+
+## Setting Up Chrome Linux Sandbox
+
+If you get an error like No usable sandbox! or Running as root without --no-sandbox is not supported, you need to properly set up sandboxing on your Linux instance.
+Alternatively, if you completely trust the content, you can disable sandboxing (strongly discouraged):
+
+
+ref. https://github.com/sindresorhus/capture-website#faq
+
+```
+import { defineConfig } from 'histoire'
+import { HstScreenshot } from '@histoire/plugin-screenshot'
+
+export default defineConfig({
+  plugins: [
+    HstScreenshot({
+      launchOptionsArgs: ['--no-sandbox', '--disable-setuid-sandbox'],
+    }),
+  ],
+})
+```
+

--- a/packages/histoire-plugin-screenshot/src/index.ts
+++ b/packages/histoire-plugin-screenshot/src/index.ts
@@ -69,9 +69,11 @@ export function HstScreenshot (options: ScreenshotPluginOptions = {}): Plugin {
         }
         console.log('Rendering screenshot for', file, 'title:', story.title, 'variant:', variant.id, 'title:', variant.title)
         for (const preset of finalOptions.presets) {
-          const launchOptions = finalOptions.launchOptionsArgs ? {
-            args: finalOptions.launchOptionsArgs
-          } : {};
+          const launchOptions = finalOptions.launchOptionsArgs
+            ? {
+              args: finalOptions.launchOptionsArgs,
+            }
+            : {}
           const captureWebsiteFileOptions: FileOptions = {
             overwrite: true,
             width: preset.width,

--- a/packages/histoire-plugin-screenshot/src/index.ts
+++ b/packages/histoire-plugin-screenshot/src/index.ts
@@ -2,6 +2,7 @@ import path from 'pathe'
 import fs from 'fs-extra'
 import type { Plugin } from 'histoire'
 import { defu } from 'defu'
+import type { FileOptions } from 'capture-website'
 
 interface ScreenshotPresets {
   /**
@@ -27,6 +28,10 @@ export interface ScreenshotPluginOptions {
    * Presets for each screenshot.
    */
   presets?: ScreenshotPresets[]
+  /**
+   * Args for puppeteer
+   */
+  launchOptionsArgs?: string[]
 }
 
 const defaultOptions: ScreenshotPluginOptions = {
@@ -64,12 +69,17 @@ export function HstScreenshot (options: ScreenshotPluginOptions = {}): Plugin {
         }
         console.log('Rendering screenshot for', file, 'title:', story.title, 'variant:', variant.id, 'title:', variant.title)
         for (const preset of finalOptions.presets) {
-          await captureWebsite.file(url, path.join(finalOptions.saveFolder, `${story.id}-${variant.id}-${preset.width}x${preset.height}.png`), {
+          const launchOptions = finalOptions.launchOptionsArgs ? {
+            args: finalOptions.launchOptionsArgs
+          } : {};
+          const captureWebsiteFileOptions: FileOptions = {
             overwrite: true,
             width: preset.width,
             height: preset.height,
             fullPage: true,
-          })
+            launchOptions,
+          }
+          await captureWebsite.file(url, path.join(finalOptions.saveFolder, `${story.id}-${variant.id}-${preset.width}x${preset.height}.png`), captureWebsiteFileOptions)
         }
       })
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add capabilities to pass some args for `captureWebsite` (and `Puppeteer`).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Puppeteer has a `launchOptions`, and we can pass them through caputre-website. https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error.
This `launchOptions` option is helpful if we have sandbox-related issues (mainly inside Docker).
But now, we cannot configure them via Histoire.

https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error
https://github.com/reg-viz/storycap/pull/23
https://github.com/reg-viz/storycap/issues/495

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- ~~[ ] Ideally, include relevant tests that fail without this PR but pass with it.~~ not test for screenshot.
