### PR TITLE
fix(MD)!: Set breaks to false in Markdown (default behavior)

### DIFF
--- a/packages/histoire/src/node/markdown.ts
+++ b/packages/histoire/src/node/markdown.ts
@@ -38,7 +38,7 @@ export async function createMarkdownRenderer (ctx: Context) {
     })}</div>`,
     linkify: true,
     html: true,
-    breaks: true,
+    breaks: false,
   })
 
   md.use(anchor, {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Setting `breaks: false` in `MarkdownIt` default config. This is default MD behavior on GitHub as well as other platforms.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The reason for this is to allow people to write Story docs in their editor and not have to write a really long single line to achieve soft wraps. Before this PR, if you did this:

```html
<docs lang="md">
# DotMenu

A simple menu component that displays a list of items in a dropdown menu. You
can supply an array of items that include the label, icon, optional color, and
action callback.
</docs>
```

It would force wrap at those points, which might look bad in some scenarios:

<img width="461" alt="CleanShot 2023-02-20 at 11 17 26@2x" src="https://user-images.githubusercontent.com/12532733/220168237-379c3a77-f83b-43a9-b378-44c501803e39.png">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
