### PR TITLE
fix: dynamic source inconsistencies

### DIFF
--- a/examples/svelte3/cypress/e2e/render-story.cy.js
+++ b/examples/svelte3/cypress/e2e/render-story.cy.js
@@ -52,3 +52,14 @@ describe('Controls render', () => {
     cy.get('[data-test-id="story-controls"] [role="checkbox"]').should('be.visible')
   })
 })
+
+describe('Dynamic source render', () => {
+  it('should render dynamic source in grid-view', () => {
+    cy.visit('/story/src-woff-story-svelte?variantId=src-woff-story-svelte-0')
+    cy.get('[data-test-id="story-source-code"] > div > pre > code > span > span').contains('Dog')
+    cy.visit('/story/src-woff-story-svelte?variantId=src-woff-story-svelte-1')
+    cy.get('[data-test-id="story-source-code"] > div > pre > code > span > span').contains('Big dog')
+    cy.visit('/story/src-woff-story-svelte?variantId=src-woff-story-svelte-2')
+    cy.get('[data-test-id="story-source-code"] > div > pre > code > span > span').contains('Hot dog')
+  })
+})

--- a/examples/svelte3/src/Woff.story.svelte
+++ b/examples/svelte3/src/Woff.story.svelte
@@ -1,0 +1,15 @@
+<script>
+  export let Hst
+</script>
+
+<Hst.Story title="Woof" layout={{ type: 'grid' }}>
+  <Hst.Variant title="Dog" source="Dog">
+    🐶
+  </Hst.Variant>
+  <Hst.Variant title="Hot dog" source="Big dog">
+    🐺
+  </Hst.Variant>
+  <Hst.Variant title="Hot dog" source="Hot dog">
+    🌭
+  </Hst.Variant>
+</Hst.Story>

--- a/packages/histoire-plugin-svelte/src/client/RenderVariant.svelte
+++ b/packages/histoire-plugin-svelte/src/client/RenderVariant.svelte
@@ -13,14 +13,6 @@ index.value++
 $: shouldRender = currentVariant.id === variant.id
 
 export let source: string = null
-
-$: {
-  if (source != null) {
-    Object.assign(currentVariant, {
-      source,
-    })
-  }
-}
 </script>
 
 {#if shouldRender}


### PR DESCRIPTION
### Description

The svelte-plugin was acting inconsistently when attempting to load multiple variants, each with their own sources. The issue seem to be related to the reactive code that runs when source is not set to null in `RenderVariant.svelte`.

The added test DOES pass without this PR, but is extremly flaky, often needing to run multiple times to pass. Running the test with the flag `--browser firefox` fails 100% of the time.

### Additional context

I've tried to break it to the best of my abilities, but so far I can't seem to be able to. Seems to me that just removing the code on line 17 in `RenderVariant.svelte` solved the issue.

Please have a go at it though!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
