### PR TITLE
fix: Ensuring that `threadsCount` results in an integer rather than a double when cpus is an odd number. (Fixes #469 )

### DIFF
--- a/packages/histoire/src/node/collect/index.ts
+++ b/packages/histoire/src/node/collect/index.ts
@@ -43,7 +43,7 @@ export function useCollectStories (options: UseCollectStoriesOptions, ctx: Conte
   const maxThreads = ctx.config.collectMaxThreads ?? cpus().length
 
   const threadsCount = ctx.mode === 'dev'
-    ? Math.max(Math.min(maxThreads, cpus().length / 2), 1)
+    ? Math.max(Math.min(maxThreads, Math.floor(cpus().length / 2)), 1)
     : Math.max(Math.min(maxThreads, cpus().length - 1), 1)
   console.log(pc.blue(`Using ${threadsCount} threads for story collection`))
 


### PR DESCRIPTION
Ensuring that `threadsCount` results in an integer rather than a double when cpus is an odd number.

### Description

Fixes #469

### Additional context

No additional context.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
