### PR TITLE
fix(nuxt): do not render app pages alongside stories (fixes #472)

### DIFF
--- a/examples/nuxt3/cypress/e2e/render-story.cy.js
+++ b/examples/nuxt3/cypress/e2e/render-story.cy.js
@@ -10,6 +10,11 @@ describe('Story render', () => {
     getIframeBody().contains('Simple story in Nuxt NuxtLink')
   })
 
+  it('should render an empty `nuxt-test` app', () => {
+    cy.visit('/story/components-simple-story-vue?variantId=_default')
+    getIframeBody().find('#nuxt-test[data-v-app]').should('be.empty')
+  })
+
   it('should render auto-imported components', () => {
     cy.visit('/story/components-autoimport-story-vue?variantId=_default')
     getIframeBody().contains('Meow')

--- a/packages/histoire-plugin-nuxt/runtime/app-component.mjs
+++ b/packages/histoire-plugin-nuxt/runtime/app-component.mjs
@@ -1,0 +1,3 @@
+export default function render () {
+  return null
+}

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -119,6 +119,7 @@ async function useNuxtViteConfig () {
       app: {
         rootId: 'nuxt-test',
       },
+      pages: false,
     },
   })
   if (nuxt.options.builder as string !== '@nuxt/vite-builder') {
@@ -129,6 +130,12 @@ async function useNuxtViteConfig () {
     { src: join(runtimeDir, 'composables.mjs'), filename: 'histoire/composables.mjs' },
     { src: join(runtimeDir, 'components.mjs'), filename: 'histoire/components.mjs' },
   )
+
+  nuxt.hook('app:templates', app => {
+    app.templates = app.templates.filter(template => template.filename !== 'app-component.mjs')
+    app.templates.push({ src: join(runtimeDir, 'app-component.mjs'), filename: 'app-component.mjs' })
+  })
+
   nuxt.hook('imports:sources', presets => {
     const stubbedComposables = ['useNuxtApp']
     const appPreset = presets.find(p => p.from === '#app')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #472

This PR stops `@histoire/plugin-nuxt` from rendering whatever is in nuxt `app` template under each story and the whole histoire page itself. 
It does so by injecting an empty compiled vue template instead of the app template.
It also disables `pages` in `nuxt.config` for the plugin not to try rendering the app routes, which avoids `vue-router` errors in console and the rendering of `404s` in place of the extra app template.

### Additional context

Please tell me if i should write a test that checks that nuxt `app` template / `404s` don't render alongside stories.
Perhaps by checking there's no additional content instead of looking for specific content.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
