### PR TITLE
fix: folderPadding and itemPadding

### DIFF
--- a/packages/histoire-app/src/app/components/tree/StoryListFolder.vue
+++ b/packages/histoire-app/src/app/components/tree/StoryListFolder.vue
@@ -25,7 +25,7 @@ function toggleOpen () {
 }
 
 const folderPadding = computed(() => {
-  return (props.depth * 12) + 'px'
+  return (props.depth +1) * 24 + 'px'
 })
 </script>
 

--- a/packages/histoire-app/src/app/components/tree/StoryListItem.vue
+++ b/packages/histoire-app/src/app/components/tree/StoryListItem.vue
@@ -14,7 +14,7 @@ const props = withDefaults(defineProps<{
 })
 
 const filePadding = computed(() => {
-  return (props.depth * 12) + 'px'
+  return (props.depth+1) * 24 + 'px'
 })
 
 const route = useRoute()


### PR DESCRIPTION
Increase padding.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
IMHO there was to small padding

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Padding size should be a preference set by  tree.padding option in histoire.setup.ts
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
