### PR TITLE
fix: histoire-vendors broken build

### DIFF
--- a/packages/histoire-vendors/rollup.config.mjs
+++ b/packages/histoire-vendors/rollup.config.mjs
@@ -79,7 +79,7 @@ export * from '${filepath}'\n`
           {
             const tempPkgFile = path.resolve(tempDir, 'package.json')
             fs.writeJsonSync(tempPkgFile, tempPkg)
-            execaSync('npm', ['install', '--prefer-offline'], { cwd: tempDir })
+            execaSync('npm', ['install', '--prefer-offline --legacy-peer-deps'], { cwd: tempDir })
             const dtsFiles = globbySync(['**/*.d.ts', '**/package.json'], {
               cwd: path.join(tempDir, 'node_modules'),
               dot: true,


### PR DESCRIPTION
Fix #504 

### Description

It seems like `npm` is having a hard time resolving dependencies of `floating-vue`.
(I have npm 9.6.2 and pnpm 8.1.0)

I just added the "--legacy-peer-deps" to allow the build of histoire-vendors.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

