### PR TITLE
feat(plugin-percy): add option to delay pupeteer screenshot and modif…

### DIFF
--- a/packages/histoire-plugin-percy/src/index.ts
+++ b/packages/histoire-plugin-percy/src/index.ts
@@ -17,10 +17,22 @@ export interface PercyPluginOptions {
    * Percy options.
    */
   percyOptions?: any
+
+  /**
+   * Delay puppeteer page screenshot after page load
+   */
+  pptrWait?: number
+
+  /**
+   * Navigation Parameter
+   */
+  pptrOptions?: any
 }
 
 const defaultOptions: PercyPluginOptions = {
   percyOptions: {},
+  pptrWait: 0,
+  pptrOptions: {}
 }
 
 export function HstPercy (options: PercyPluginOptions = {}): Plugin {
@@ -57,7 +69,9 @@ export function HstPercy (options: PercyPluginOptions = {}): Plugin {
         }
 
         const page = await browser.newPage()
-        await page.goto(url)
+        await page.goto(url, finalOptions.pptrOptions)
+
+        await new Promise(resolve => setTimeout(resolve, finalOptions.pptrWait));
 
         const name = `${story.title} > ${variant.title}`
         await page.evaluate(await fetchPercyDOM())

--- a/packages/histoire-plugin-percy/src/index.ts
+++ b/packages/histoire-plugin-percy/src/index.ts
@@ -32,7 +32,7 @@ export interface PercyPluginOptions {
 const defaultOptions: PercyPluginOptions = {
   percyOptions: {},
   pptrWait: 0,
-  pptrOptions: {}
+  pptrOptions: {},
 }
 
 export function HstPercy (options: PercyPluginOptions = {}): Plugin {
@@ -71,7 +71,7 @@ export function HstPercy (options: PercyPluginOptions = {}): Plugin {
         const page = await browser.newPage()
         await page.goto(url, finalOptions.pptrOptions)
 
-        await new Promise(resolve => setTimeout(resolve, finalOptions.pptrWait));
+        await new Promise(resolve => setTimeout(resolve, finalOptions.pptrWait))
 
         const name = `${story.title} > ${variant.title}`
         await page.evaluate(await fetchPercyDOM())


### PR DESCRIPTION
### Description

Pupeteer needs sometimes more time to render a page. There are multiple ways to solve this, in this PR there are 2 ways implemented. One option to wait x seconds and one options to listen for a network change using pupeteers native options.

https://github.com/histoire-dev/histoire/issues/485
https://github.com/histoire-dev/histoire/issues/373
https://github.com/histoire-dev/histoire/issues/357

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature



