### PR TITLE
fix(nuxt): pass nuxt runtimeConfig into nuxt app stub (fix #494)

### DIFF
--- a/examples/nuxt3/components/AutoImport.story.vue
+++ b/examples/nuxt3/components/AutoImport.story.vue
@@ -12,5 +12,8 @@ console.log('useRuntimeConfig', config)
 
     <h3>Nuxt runtime config</h3>
     <pre>{{ config }}</pre>
+    <p data-testid="config">
+      {{ config.public.configFromNuxt }}
+    </p>
   </Story>
 </template>

--- a/examples/nuxt3/cypress/e2e/render-story.cy.js
+++ b/examples/nuxt3/cypress/e2e/render-story.cy.js
@@ -24,4 +24,9 @@ describe('Story render', () => {
     cy.visit('/story/components-basebuttonlink-story-vue?variantId=_default')
     cy.get('.histoire-generic-render-story a').contains('Hello world')
   })
+
+  it('should render the public config populated from Nuxt', () => {
+    cy.visit('/story/components-autoimport-story-vue?variantId=_default')
+    getIframeBody().find('.histoire-generic-render-story p[data-testid="config"]').contains('test')
+  })
 })

--- a/examples/nuxt3/nuxt.config.ts
+++ b/examples/nuxt3/nuxt.config.ts
@@ -3,4 +3,9 @@ export default defineNuxtConfig({
   modules: [
     '@nuxtjs/tailwindcss',
   ],
+  runtimeConfig: {
+    public: {
+      configFromNuxt: 'test',
+    },
+  },
 })

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -28,6 +28,7 @@ export function HstNuxt (): Plugin {
     async defaultConfig () {
       const nuxtViteConfig = await useNuxtViteConfig()
       const { viteConfig } = nuxtViteConfig
+
       nuxt = nuxtViteConfig.nuxt // We save it to close it later
       const plugins = viteConfig.plugins.filter((p: any) => !ignorePlugins.includes(p?.name))
       return {
@@ -63,7 +64,7 @@ export function HstNuxt (): Plugin {
           `${nuxt.options.css.map(file => `import '${file}'`).join('\n')}`,
           `import { setupNuxtApp } from '@histoire/plugin-nuxt/dist/runtime/app-setup.js'
 export async function setupVue3 () {
-  await setupNuxtApp()
+  await setupNuxtApp(${JSON.stringify(nuxt.options.runtimeConfig.public)})
 }`,
         ],
         viteNodeInlineDeps: [

--- a/packages/histoire-plugin-nuxt/src/runtime/app-setup.ts
+++ b/packages/histoire-plugin-nuxt/src/runtime/app-setup.ts
@@ -1,8 +1,9 @@
+import { PublicRuntimeConfig } from '@nuxt/schema'
 import type { App } from 'h3'
 import { createApp } from 'h3'
 import { createFetch } from 'ofetch'
 
-export async function setupNuxtApp () {
+export async function setupNuxtApp (publicConfig: PublicRuntimeConfig) {
   const win = window as unknown as Window & {
     __app: App
     __registry: Set<string>
@@ -16,7 +17,7 @@ export async function setupNuxtApp () {
   win.__NUXT__ = {
     serverRendered: false,
     config: {
-      public: {},
+      public: { ...publicConfig },
       app: { baseURL: '/' },
     },
     data: {},


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes #494

I've made the setupNuxtApp function to accept the current Nuxt instance's public runtime config that is returned from loadNuxt and also passed in that value into setupCode in an 'eval' like fashion through JSON.stringify.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
This should address the issue at hand, but may also fix compatibility issues with other Nuxt modules which may populate the public runtime config as part of their initialisation such as @storyblok/nuxt (I've encountered this issue on another project while attempting to integrate Histoire).

Relevant line: https://github.com/storyblok/storyblok-nuxt/blob/8874551fa331c72921cd4a8279c67089311c5750/src/module.ts#L57
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
