### PR TITLE
fix: adjust tree file path if it's a plugin (fix #276)

### DIFF
--- a/packages/histoire/src/node/tree.ts
+++ b/packages/histoire/src/node/tree.ts
@@ -14,6 +14,14 @@ export function createPath (config: HistoireConfig, file: ServerTreeFile) {
 
   if (config.tree.file === 'path') {
     const paths = file.path.split('/').slice(0, -1)
+
+    // check if tree file path is a plugin
+    const index = paths.findIndex(p => p.includes('.histoire'))
+
+    if (index !== -1) {
+      return ['plugins', file.title]
+    }
+
     return [...paths, file.title]
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes #276.

Added a conditional for verifying if the tree file path includes ".histoire" which identifies it as being a plugin.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
