### PR TITLE
chore: fix ecosystem-ci

### DIFF
--- a/examples/svelte3/package.json
+++ b/examples/svelte3/package.json
@@ -22,6 +22,6 @@
     "histoire": "workspace:*",
     "start-server-and-test": "^1.14.0",
     "svelte-preprocess": "^4.10.7",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -29,6 +29,6 @@
     "svelte-preprocess": "^4.10.7",
     "tslib": "^2.3.1",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -14,7 +14,7 @@
     "@histoire/plugin-vue2": "workspace:*",
     "@vitejs/plugin-vue2": "^2.1.0",
     "histoire": "workspace:*",
-    "vite": "^4.2.0",
+    "vite": "^4.4.8",
     "vue-template-compiler": "^2.7.8"
   }
 }

--- a/examples/vue3-percy/package.json
+++ b/examples/vue3-percy/package.json
@@ -15,6 +15,6 @@
     "@histoire/plugin-vue": "workspace:*",
     "@vitejs/plugin-vue": "^4.0.0",
     "histoire": "workspace:*",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/examples/vue3-screenshot/package.json
+++ b/examples/vue3-screenshot/package.json
@@ -15,6 +15,6 @@
     "@histoire/plugin-vue": "workspace:*",
     "@vitejs/plugin-vue": "^4.0.0",
     "histoire": "workspace:*",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/examples/vue3-themed/package.json
+++ b/examples/vue3-themed/package.json
@@ -12,9 +12,9 @@
     "vue": "^3.2.47"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0",
     "@histoire/plugin-vue": "workspace:*",
+    "@vitejs/plugin-vue": "^4.0.0",
     "histoire": "workspace:*",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/examples/vue3-vuetify/package.json
+++ b/examples/vue3-vuetify/package.json
@@ -13,10 +13,10 @@
     "vuetify": "^3.0.0-beta.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^2.3.1",
     "@histoire/plugin-vue": "workspace:*",
+    "@vitejs/plugin-vue": "^2.3.1",
     "histoire": "workspace:*",
-    "vite": "^2.9.1",
+    "vite": "^4.4.8",
     "vite-plugin-vuetify": "1.0.0-alpha.12"
   }
 }

--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -27,6 +27,6 @@
     "nodemon": "^2.0.20",
     "sass": "^1.50.0",
     "start-server-and-test": "^1.14.0",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/packages/histoire-app/package.json
+++ b/packages/histoire-app/package.json
@@ -51,7 +51,7 @@
     "postcss-import": "^14.1.0",
     "tailwindcss": "^3.0.23",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0",
+    "vite": "^4.4.8",
     "vue": "^3.2.47"
   }
 }

--- a/packages/histoire-controls-stories/package.json
+++ b/packages/histoire-controls-stories/package.json
@@ -26,6 +26,6 @@
     "@histoire/plugin-vue": "workspace:*",
     "@vitejs/plugin-vue": "^4.0.0",
     "histoire": "workspace:*",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/packages/histoire-controls/package.json
+++ b/packages/histoire-controls/package.json
@@ -55,6 +55,7 @@
     "@peeky/test": "^0.14.1",
     "@types/node": "^17.0.32",
     "@vitejs/plugin-vue": "^4.0.0",
+    "@vue/runtime-dom": "^3.3.4",
     "@vue/test-utils": "^2.2.10",
     "@vueuse/core": "^9.12.0",
     "autoprefixer": "^10.4.4",
@@ -64,7 +65,7 @@
     "postcss-import": "^14.1.0",
     "tailwindcss": "^3.0.23",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0",
+    "vite": "^4.4.8",
     "vue": "^3.2.47",
     "vue-tsc": "^1.0.24"
   }

--- a/packages/histoire-plugin-nuxt/package.json
+++ b/packages/histoire-plugin-nuxt/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^17.0.32",
     "histoire": "workspace:*",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   },
   "peerDependencies": {
     "@histoire/plugin-vue": "workspace:^",

--- a/packages/histoire-plugin-svelte/package.json
+++ b/packages/histoire-plugin-svelte/package.json
@@ -51,13 +51,13 @@
     "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "@types/node": "^17.0.32",
     "concurrently": "^7.1.0",
-    "typescript": "^4.9.5",
     "fs-extra": "^10.0.1",
     "globby": "^13.1.1",
     "histoire": "workspace:*",
     "svelte": "^3.49.0",
     "svelte-preprocess": "^4.10.7",
-    "vite": "^4.2.0"
+    "typescript": "^4.9.5",
+    "vite": "^4.4.8"
   },
   "peerDependencies": {
     "histoire": "workspace:^",

--- a/packages/histoire-plugin-vue/package.json
+++ b/packages/histoire-plugin-vue/package.json
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@types/node": "^17.0.32",
     "concurrently": "^7.1.0",
-    "typescript": "^4.9.5",
     "histoire": "workspace:*",
-    "vite": "^4.2.0",
+    "typescript": "^4.9.5",
+    "vite": "^4.4.8",
     "vue": "^3.2.47"
   },
   "peerDependencies": {

--- a/packages/histoire-plugin-vue2/package.json
+++ b/packages/histoire-plugin-vue2/package.json
@@ -49,7 +49,7 @@
     "globby": "^13.1.1",
     "histoire": "workspace:*",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0",
+    "vite": "^4.4.8",
     "vue": "^2.7.8"
   },
   "peerDependencies": {

--- a/packages/histoire-shared/package.json
+++ b/packages/histoire-shared/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "typescript": "^4.9.5",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/packages/histoire/package.json
+++ b/packages/histoire/package.json
@@ -85,8 +85,9 @@
     "@types/markdown-it": "^12.2.3",
     "@types/micromatch": "^4.0.2",
     "@types/node": "^17.0.32",
+    "esbuild": "^0.18.19",
     "rollup": "^3.5.1",
     "typescript": "^4.9.5",
-    "vite": "^4.2.0"
+    "vite": "^4.4.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
         version: link:../../packages/histoire-plugin-svelte
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.0.0
-        version: 2.0.2(svelte@3.55.1)(vite@4.2.0)
+        version: 2.0.2(svelte@3.55.1)(vite@4.4.8)
       cypress:
         specifier: ^10.8.0
         version: 10.11.0
@@ -133,8 +133,8 @@ importers:
         specifier: ^4.10.7
         version: 4.10.7(postcss@8.4.21)(svelte@3.55.1)(typescript@4.9.5)
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   examples/sveltekit:
     dependencies:
@@ -153,7 +153,7 @@ importers:
         version: 1.0.2(@sveltejs/kit@1.3.10)
       '@sveltejs/kit':
         specifier: ^1.0.0
-        version: 1.3.10(svelte@3.55.1)(vite@4.2.0)
+        version: 1.3.10(svelte@3.55.1)(vite@4.4.8)
       '@types/cookie':
         specifier: ^0.5.1
         version: 0.5.1
@@ -176,8 +176,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   examples/vue2:
     dependencies:
@@ -190,13 +190,13 @@ importers:
         version: link:../../packages/histoire-plugin-vue2
       '@vitejs/plugin-vue2':
         specifier: ^2.1.0
-        version: 2.2.0(vite@4.2.0)(vue@2.7.14)
+        version: 2.2.0(vite@4.4.8)(vue@2.7.14)
       histoire:
         specifier: workspace:*
         version: link:../../packages/histoire
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vue-template-compiler:
         specifier: ^2.7.8
         version: 2.7.14
@@ -224,7 +224,7 @@ importers:
         version: link:../../packages/histoire-vendors
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       cypress:
         specifier: ^9.5.3
         version: 9.7.0
@@ -241,8 +241,8 @@ importers:
         specifier: ^1.14.0
         version: 1.15.3
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(sass@1.58.0)
+        specifier: ^4.4.8
+        version: 4.4.8(sass@1.58.0)
 
   examples/vue3-percy:
     dependencies:
@@ -258,13 +258,13 @@ importers:
         version: link:../../packages/histoire-plugin-vue
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       histoire:
         specifier: workspace:*
         version: link:../../packages/histoire
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   examples/vue3-screenshot:
     dependencies:
@@ -280,13 +280,13 @@ importers:
         version: link:../../packages/histoire-plugin-vue
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       histoire:
         specifier: workspace:*
         version: link:../../packages/histoire
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   examples/vue3-themed:
     dependencies:
@@ -299,13 +299,13 @@ importers:
         version: link:../../packages/histoire-plugin-vue
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       histoire:
         specifier: workspace:*
         version: link:../../packages/histoire
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   examples/vue3-vuetify:
     dependencies:
@@ -324,16 +324,16 @@ importers:
         version: link:../../packages/histoire-plugin-vue
       '@vitejs/plugin-vue':
         specifier: ^2.3.1
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        version: 2.3.4(vite@4.4.8)(vue@3.2.47)
       histoire:
         specifier: workspace:*
         version: link:../../packages/histoire
       vite:
-        specifier: ^2.9.1
-        version: 2.9.15
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vite-plugin-vuetify:
         specifier: 1.0.0-alpha.12
-        version: 1.0.0-alpha.12(vite@2.9.15)(vue@3.2.47)(vuetify@3.1.3)
+        version: 1.0.0-alpha.12(vite@4.4.8)(vue@3.2.47)(vuetify@3.1.3)
 
   packages/histoire:
     dependencies:
@@ -446,6 +446,9 @@ importers:
       '@types/node':
         specifier: ^17.0.32
         version: 17.0.45
+      esbuild:
+        specifier: ^0.18.19
+        version: 0.18.19
       rollup:
         specifier: ^3.5.1
         version: 3.14.0
@@ -453,8 +456,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   packages/histoire-app:
     dependencies:
@@ -488,7 +491,7 @@ importers:
         version: 17.0.45
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       autoprefixer:
         specifier: ^10.4.4
         version: 10.4.13(postcss@8.4.21)
@@ -520,8 +523,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vue:
         specifier: ^3.2.47
         version: 3.2.47
@@ -567,7 +570,10 @@ importers:
         version: 17.0.45
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
+      '@vue/runtime-dom':
+        specifier: ^3.3.4
+        version: 3.3.4
       '@vue/test-utils':
         specifier: ^2.2.10
         version: 2.2.10(vue@3.2.47)
@@ -596,8 +602,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vue:
         specifier: ^3.2.47
         version: 3.2.47
@@ -619,13 +625,13 @@ importers:
         version: link:../histoire-plugin-vue
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.2.0)(vue@3.2.47)
+        version: 4.0.0(vite@4.4.8)(vue@3.2.47)
       histoire:
         specifier: workspace:*
         version: link:../histoire
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   packages/histoire-plugin-nuxt:
     dependencies:
@@ -637,10 +643,10 @@ importers:
         version: 3.1.2(rollup@3.14.0)
       '@vitejs/plugin-vue':
         specifier: ^4.1.0
-        version: 4.1.0(vite@4.2.0)
+        version: 4.1.0(vite@4.4.8)
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.1
-        version: 3.0.1(vite@4.2.0)
+        version: 3.0.1(vite@4.4.8)
       h3:
         specifier: ^1.4.0
         version: 1.4.0
@@ -667,8 +673,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   packages/histoire-plugin-percy:
     dependencies:
@@ -749,7 +755,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.1
-        version: 1.4.0(svelte@3.55.1)(vite@4.2.0)
+        version: 1.4.0(svelte@3.55.1)(vite@4.4.8)
       '@types/node':
         specifier: ^17.0.32
         version: 17.0.45
@@ -772,8 +778,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   packages/histoire-plugin-vue:
     dependencies:
@@ -812,8 +818,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vue:
         specifier: ^3.2.47
         version: 3.2.47
@@ -849,8 +855,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
       vue:
         specifier: ^2.7.8
         version: 2.7.14
@@ -880,8 +886,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@17.0.45)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@17.0.45)
 
   packages/histoire-vendors:
     devDependencies:
@@ -1235,7 +1241,7 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.15
+      '@babel/parser': 7.22.7
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
@@ -1273,7 +1279,7 @@ packages:
     resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -1290,7 +1296,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -1376,7 +1382,7 @@ packages:
     resolution: {integrity: sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -1395,7 +1401,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -1418,7 +1424,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
@@ -1433,7 +1439,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1447,7 +1453,7 @@ packages:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -1459,8 +1465,17 @@ packages:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option@7.18.6:
@@ -1477,7 +1492,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -1495,7 +1510,7 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -1512,6 +1527,13 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.4
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -1605,8 +1627,8 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.20.7
       debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1643,6 +1665,14 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage@0.2.3:
@@ -1848,11 +1878,10 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.17.5:
-    resolution: {integrity: sha512-KHWkDqYAMmKZjY4RAN1PR96q6UOtfkWlTS8uEwWxdLtkRt/0F/csUhXIrVfaSIFxnscIBMPynGfhsMwQDRIBQw==}
+  /@esbuild/android-arm64@0.18.19:
+    resolution: {integrity: sha512-4+jkUFQxZkQfQOOxfGVZB38YUWHMJX2ihZwF+2nh8m7bHdWXpixiurgGRN3c/KMSwlltbYI0/i929jwBRMFzbA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1883,11 +1912,10 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/android-arm@0.17.5:
-    resolution: {integrity: sha512-crmPUzgCmF+qZXfl1YkiFoUta2XAfixR1tEnr/gXIixE+WL8Z0BGqfydP5oox0EUOgQMMRgtATtakyAcClQVqQ==}
+  /@esbuild/android-arm@0.18.19:
+    resolution: {integrity: sha512-1uOoDurJYh5MNqPqpj3l/TQCI1V25BXgChEldCB7D6iryBYqYKrbZIhYO5AI9fulf66sM8UJpc3UcCly2Tv28w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -1909,11 +1937,10 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.5:
-    resolution: {integrity: sha512-8fI/AnIdmWz/+1iza2WrCw8kwXK9wZp/yZY/iS8ioC+U37yJCeppi9EHY05ewJKN64ASoBIseufZROtcFnX5GA==}
+  /@esbuild/android-x64@0.18.19:
+    resolution: {integrity: sha512-ae5sHYiP/Ogj2YNrLZbWkBmyHIDOhPgpkGvFnke7XFGQldBDWvc/AyYwSLpNuKw9UNkgnLlB/jPpnBmlF3G9Bg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1935,11 +1962,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.5:
-    resolution: {integrity: sha512-EAvaoyIySV6Iif3NQCglUNpnMfHSUgC5ugt2efl3+QDntucJe5spn0udNZjTgNi6tKVqSceOw9tQ32liNZc1Xw==}
+  /@esbuild/darwin-arm64@0.18.19:
+    resolution: {integrity: sha512-HIpQvNQWFYROmWDANMRL+jZvvTQGOiTuwWBIuAsMaQrnStedM+nEKJBzKQ6bfT9RFKH2wZ+ej+DY7+9xHBTFPg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1961,11 +1987,10 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.5:
-    resolution: {integrity: sha512-ha7QCJh1fuSwwCgoegfdaljowwWozwTDjBgjD3++WAy/qwee5uUi1gvOg2WENJC6EUyHBOkcd3YmLDYSZ2TPPA==}
+  /@esbuild/darwin-x64@0.18.19:
+    resolution: {integrity: sha512-m6JdvXJQt0thNLIcWOeG079h2ivhYH4B5sVCgqb/B29zTcFd7EE8/J1nIUHhdtwGeItdUeqKaqqb4towwxvglQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1987,11 +2012,10 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.5:
-    resolution: {integrity: sha512-VbdXJkn2aI2pQ/wxNEjEcnEDwPpxt3CWWMFYmO7CcdFBoOsABRy2W8F3kjbF9F/pecEUDcI3b5i2w+By4VQFPg==}
+  /@esbuild/freebsd-arm64@0.18.19:
+    resolution: {integrity: sha512-G0p4EFMPZhGn/xVNspUyMQbORH3nlKTV0bFNHPIwLraBuAkTeMyxNviTe0ZXUbIXQrR1lrwniFjNFU4s+x7veQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -2013,11 +2037,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.5:
-    resolution: {integrity: sha512-olgGYND1/XnnWxwhjtY3/ryjOG/M4WfcA6XH8dBTH1cxMeBemMODXSFhkw71Kf4TeZFFTN25YOomaNh0vq2iXg==}
+  /@esbuild/freebsd-x64@0.18.19:
+    resolution: {integrity: sha512-hBxgRlG42+W+j/1/cvlnSa+3+OBKeDCyO7OG2ICya1YJaSCYfSpuG30KfOnQHI7Ytgu4bRqCgrYXxQEzy0zM5Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -2039,11 +2062,10 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.5:
-    resolution: {integrity: sha512-8a0bqSwu3OlLCfu2FBbDNgQyBYdPJh1B9PvNX7jMaKGC9/KopgHs37t+pQqeMLzcyRqG6z55IGNQAMSlCpBuqg==}
+  /@esbuild/linux-arm64@0.18.19:
+    resolution: {integrity: sha512-X8g33tczY0GsJq3lhyBrjnFtaKjWVpp1gMq5IlF9BQJ3TUfSK74nQnz9mRIEejmcV+OIYn6bkOJeUaU1Knrljg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -2065,11 +2087,10 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.5:
-    resolution: {integrity: sha512-YBdCyQwA3OQupi6W2/WO4FnI+NWFWe79cZEtlbqSESOHEg7a73htBIRiE6uHPQe7Yp5E4aALv+JxkRLGEUL7tw==}
+  /@esbuild/linux-arm@0.18.19:
+    resolution: {integrity: sha512-qtWyoQskfJlb9MD45mvzCEKeO4uCnDZ7lPFeNqbfaaJHqBiH9qA5Vu2EuckqYZuFMJWy1l4dxTf9NOulCVfUjg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -2091,11 +2112,10 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.5:
-    resolution: {integrity: sha512-uCwm1r/+NdP7vndctgq3PoZrnmhmnecWAr114GWMRwg2QMFFX+kIWnp7IO220/JLgnXK/jP7VKAFBGmeOYBQYQ==}
+  /@esbuild/linux-ia32@0.18.19:
+    resolution: {integrity: sha512-SAkRWJgb+KN+gOhmbiE6/wu23D6HRcGQi15cB13IVtBZZgXxygTV5GJlUAKLQ5Gcx0gtlmt+XIxEmSqA6sZTOw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -2108,6 +2128,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.15.18:
@@ -2134,11 +2155,10 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.5:
-    resolution: {integrity: sha512-3YxhSBl5Sb6TtBjJu+HP93poBruFzgXmf3PVfIe4xOXMj1XpxboYZyw3W8BhoX/uwxzZz4K1I99jTE/5cgDT1g==}
+  /@esbuild/linux-loong64@0.18.19:
+    resolution: {integrity: sha512-YLAslaO8NsB9UOxBchos82AOMRDbIAWChwDKfjlGrHSzS3v1kxce7dGlSTsrb0PJwo1KYccypN3VNjQVLtz7LA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2160,11 +2180,10 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.5:
-    resolution: {integrity: sha512-Hy5Z0YVWyYHdtQ5mfmfp8LdhVwGbwVuq8mHzLqrG16BaMgEmit2xKO+iDakHs+OetEx0EN/2mUzDdfdktI+Nmg==}
+  /@esbuild/linux-mips64el@0.18.19:
+    resolution: {integrity: sha512-vSYFtlYds/oTI8aflEP65xo3MXChMwBOG1eWPGGKs/ev9zkTeXVvciU+nifq8J1JYMz+eQ4J9JDN0O2RKF8+1Q==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -2186,11 +2205,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.5:
-    resolution: {integrity: sha512-5dbQvBLbU/Y3Q4ABc9gi23hww1mQcM7KZ9KBqabB7qhJswYMf8WrDDOSw3gdf3p+ffmijMd28mfVMvFucuECyg==}
+  /@esbuild/linux-ppc64@0.18.19:
+    resolution: {integrity: sha512-tgG41lRVwlzqO9tv9l7aXYVw35BxKXLtPam1qALScwSqPivI8hjkZLNH0deaaSCYCFT9cBIdB+hUjWFlFFLL9A==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2212,11 +2230,10 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.5:
-    resolution: {integrity: sha512-fp/KUB/ZPzEWGTEUgz9wIAKCqu7CjH1GqXUO2WJdik1UNBQ7Xzw7myIajpxztE4Csb9504ERiFMxZg5KZ6HlZQ==}
+  /@esbuild/linux-riscv64@0.18.19:
+    resolution: {integrity: sha512-EgBZFLoN1S5RuB4cCJI31pBPsjE1nZ+3+fHRjguq9Ibrzo29bOLSBcH1KZJvRNh5qtd+fcYIGiIUia8Jw5r1lQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -2238,11 +2255,10 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.5:
-    resolution: {integrity: sha512-kRV3yw19YDqHTp8SfHXfObUFXlaiiw4o2lvT1XjsPZ++22GqZwSsYWJLjMi1Sl7j9qDlDUduWDze/nQx0d6Lzw==}
+  /@esbuild/linux-s390x@0.18.19:
+    resolution: {integrity: sha512-q1V1rtHRojAzjSigZEqrcLkpfh5K09ShCoIsdTakozVBnM5rgV58PLFticqDp5UJ9uE0HScov9QNbbl8HBo6QQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2264,11 +2280,10 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.5:
-    resolution: {integrity: sha512-vnxuhh9e4pbtABNLbT2ANW4uwQ/zvcHRCm1JxaYkzSehugoFd5iXyC4ci1nhXU13mxEwCnrnTIiiSGwa/uAF1g==}
+  /@esbuild/linux-x64@0.18.19:
+    resolution: {integrity: sha512-D0IiYjpZRXxGZLQfsydeAD7ZWqdGyFLBj5f2UshJpy09WPs3qizDCsEr8zyzcym6Woj/UI9ZzMIXwvoXVtyt0A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -2290,11 +2305,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.5:
-    resolution: {integrity: sha512-cigBpdiSx/vPy7doUyImsQQBnBjV5f1M99ZUlaJckDAJjgXWl6y9W17FIfJTy8TxosEF6MXq+fpLsitMGts2nA==}
+  /@esbuild/netbsd-x64@0.18.19:
+    resolution: {integrity: sha512-3tt3SOS8L3D54R8oER41UdDshlBIAjYhdWRPiZCTZ1E41+shIZBpTjaW5UaN/jD1ENE/Ok5lkeqhoNMbxstyxw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -2316,11 +2330,10 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.5:
-    resolution: {integrity: sha512-VdqRqPVIjjZfkf40LrqOaVuhw9EQiAZ/GNCSM2UplDkaIzYVsSnycxcFfAnHdWI8Gyt6dO15KHikbpxwx+xHbw==}
+  /@esbuild/openbsd-x64@0.18.19:
+    resolution: {integrity: sha512-MxbhcuAYQPlfln1EMc4T26OUoeg/YQc6wNoEV8xvktDKZhLtBxjkoeESSo9BbPaGKhAPzusXYj5n8n5A8iZSrA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -2342,11 +2355,10 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.5:
-    resolution: {integrity: sha512-ItxPaJ3MBLtI4nK+mALLEoUs6amxsx+J1ibnfcYMkqaCqHST1AkF4aENpBehty3czqw64r/XqL+W9WqU6kc2Qw==}
+  /@esbuild/sunos-x64@0.18.19:
+    resolution: {integrity: sha512-m0/UOq1wj25JpWqOJxoWBRM9VWc3c32xiNzd+ERlYstUZ6uwx5SZsQUtkiFHaYmcaoj+f6+Tfcl7atuAz3idwQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -2368,11 +2380,10 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.5:
-    resolution: {integrity: sha512-4u2Q6qsJTYNFdS9zHoAi80spzf78C16m2wla4eJPh4kSbRv+BpXIfl6TmBSWupD8e47B1NrTfrOlEuco7mYQtg==}
+  /@esbuild/win32-arm64@0.18.19:
+    resolution: {integrity: sha512-L4vb6pcoB1cEcXUHU6EPnUhUc4+/tcz4OqlXTWPcSQWxegfmcOprhmIleKKwmMNQVc4wrx/+jB7tGkjjDmiupg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -2394,11 +2405,10 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.5:
-    resolution: {integrity: sha512-KYlm+Xu9TXsfTWAcocLuISRtqxKp/Y9ZBVg6CEEj0O5J9mn7YvBKzAszo2j1ndyzUPk+op+Tie2PJeN+BnXGqQ==}
+  /@esbuild/win32-ia32@0.18.19:
+    resolution: {integrity: sha512-rQng7LXSKdrDlNDb7/v0fujob6X0GAazoK/IPd9C3oShr642ri8uIBkgM37/l8B3Rd5sBQcqUXoDdEy75XC/jg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -2420,11 +2430,10 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.5:
-    resolution: {integrity: sha512-XgA9qWRqby7xdYXuF6KALsn37QGBMHsdhmnpjfZtYxKxbTOwfnDM6MYi2WuUku5poNaX2n9XGVr20zgT/2QwCw==}
+  /@esbuild/win32-x64@0.18.19:
+    resolution: {integrity: sha512-z69jhyG20Gq4QL5JKPLqUT+eREuqnDAFItLbza4JCmpvUnIlY73YNjd5djlO7kBiiZnvTnJuAbOjIoZIOa1GjA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2925,13 +2934,13 @@ packages:
     dependencies:
       '@nuxt/kit': 3.1.2(rollup@3.14.0)
       '@rollup/plugin-replace': 5.0.2(rollup@3.14.0)
-      '@vitejs/plugin-vue': 4.0.0(vite@4.1.1)(vue@3.2.47)
-      '@vitejs/plugin-vue-jsx': 3.0.0(vite@4.1.1)(vue@3.2.47)
+      '@vitejs/plugin-vue': 4.0.0(vite@4.1.5)(vue@3.2.47)
+      '@vitejs/plugin-vue-jsx': 3.0.0(vite@4.1.5)(vue@3.2.47)
       autoprefixer: 10.4.13(postcss@8.4.21)
       chokidar: 3.5.3
       cssnano: 5.1.14(postcss@8.4.21)
       defu: 6.1.2
-      esbuild: 0.17.5
+      esbuild: 0.17.16
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       externality: 1.0.0
@@ -2952,15 +2961,16 @@ packages:
       rollup-plugin-visualizer: 5.9.0(rollup@3.14.0)
       ufo: 1.0.1
       unplugin: 1.0.1
-      vite: 4.1.1(@types/node@17.0.45)
+      vite: 4.1.5(@types/node@17.0.45)
       vite-node: 0.28.4(@types/node@17.0.45)
-      vite-plugin-checker: 0.5.5(eslint@8.33.0)(typescript@4.9.5)(vite@4.1.1)
+      vite-plugin-checker: 0.5.5(eslint@8.33.0)(typescript@4.9.5)(vite@4.1.5)
       vue: 3.2.47
       vue-bundle-renderer: 1.0.0
     transitivePeerDependencies:
       - '@types/node'
       - eslint
       - less
+      - lightningcss
       - meow
       - optionator
       - sass
@@ -2986,8 +2996,8 @@ packages:
     dependencies:
       '@nuxt/kit': 3.3.3
       '@rollup/plugin-replace': 5.0.2(rollup@3.14.0)
-      '@vitejs/plugin-vue': 4.1.0(vite@4.2.1)(vue@3.2.47)
-      '@vitejs/plugin-vue-jsx': 3.0.1(vite@4.2.1)(vue@3.2.47)
+      '@vitejs/plugin-vue': 4.1.0(vite@4.2.3)(vue@3.2.47)
+      '@vitejs/plugin-vue-jsx': 3.0.1(vite@4.2.3)(vue@3.2.47)
       autoprefixer: 10.4.14(postcss@8.4.21)
       chokidar: 3.5.3
       clear: 0.1.0
@@ -3015,15 +3025,16 @@ packages:
       strip-literal: 1.0.1
       ufo: 1.1.1
       unplugin: 1.3.1
-      vite: 4.2.1
+      vite: 4.2.3
       vite-node: 0.29.8
-      vite-plugin-checker: 0.5.6(eslint@8.33.0)(typescript@4.9.5)(vite@4.2.1)
+      vite-plugin-checker: 0.5.6(eslint@8.33.0)(typescript@4.9.5)(vite@4.2.3)
       vue: 3.2.47
       vue-bundle-renderer: 1.0.3
     transitivePeerDependencies:
       - '@types/node'
       - eslint
       - less
+      - lightningcss
       - meow
       - optionator
       - rollup
@@ -3108,7 +3119,7 @@ packages:
       fs-extra: 10.1.0
       nanoid: 4.0.1
       pathe: 0.3.9
-      vite: 3.2.5(@types/node@17.0.45)
+      vite: 3.2.7(@types/node@17.0.45)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3157,7 +3168,7 @@ packages:
       slugify: 1.6.5
       source-map-support: 0.5.21
       tinypool: 0.3.1
-      vite: 3.2.5(@types/node@17.0.45)
+      vite: 3.2.7(@types/node@17.0.45)
       vite-node: 0.3.6
     transitivePeerDependencies:
       - '@types/node'
@@ -3194,7 +3205,7 @@ packages:
       object-inspect: 1.12.3
       pathe: 0.3.9
       slugify: 1.6.5
-      vite: 3.2.5(@types/node@17.0.45)
+      vite: 3.2.7(@types/node@17.0.45)
       ws: 8.12.0
     transitivePeerDependencies:
       - '@types/node'
@@ -3676,11 +3687,11 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.3.10(svelte@3.55.1)(vite@4.2.0)
+      '@sveltejs/kit': 1.3.10(svelte@3.55.1)(vite@4.4.8)
       import-meta-resolve: 2.2.1
     dev: true
 
-  /@sveltejs/kit@1.3.10(svelte@3.55.1)(vite@4.2.0):
+  /@sveltejs/kit@1.3.10(svelte@3.55.1)(vite@4.4.8):
     resolution: {integrity: sha512-I3DgWCwTYbTz4ZPCJIRkSDrKkMu0bsdk6ghqsOBVNqesf1wBdTdfkXhag3ESWgIEjUV3VUIWPQF7fnt7328mhQ==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -3689,7 +3700,7 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0 || ^2.9.0 || ^3.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.0.2(svelte@3.55.1)(vite@4.2.0)
+      '@sveltejs/vite-plugin-svelte': 2.0.2(svelte@3.55.1)(vite@4.4.8)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.2.3
@@ -3703,12 +3714,12 @@ packages:
       svelte: 3.55.1
       tiny-glob: 0.2.9
       undici: 5.16.0
-      vite: 4.2.0(@types/node@17.0.45)
+      vite: 4.4.8(@types/node@17.0.45)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.55.1)(vite@4.2.0):
+  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.55.1)(vite@4.4.8):
     resolution: {integrity: sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -3721,13 +3732,13 @@ packages:
       magic-string: 0.26.7
       svelte: 3.55.1
       svelte-hmr: 0.15.1(svelte@3.55.1)
-      vite: 4.2.0(@types/node@17.0.45)
-      vitefu: 0.2.4(vite@4.2.0)
+      vite: 4.4.8(@types/node@17.0.45)
+      vitefu: 0.2.4(vite@4.4.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.55.1)(vite@4.2.0):
+  /@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.55.1)(vite@4.4.8):
     resolution: {integrity: sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -3740,8 +3751,8 @@ packages:
       magic-string: 0.27.0
       svelte: 3.55.1
       svelte-hmr: 0.15.1(svelte@3.55.1)
-      vite: 4.2.0(@types/node@17.0.45)
-      vitefu: 0.2.4(vite@4.2.0)
+      vite: 4.4.8(@types/node@17.0.45)
+      vitefu: 0.2.4(vite@4.4.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4247,7 +4258,7 @@ packages:
       - encoding
       - supports-color
 
-  /@vitejs/plugin-vue-jsx@3.0.0(vite@4.1.1)(vue@3.2.47):
+  /@vitejs/plugin-vue-jsx@3.0.0(vite@4.1.5)(vue@3.2.47):
     resolution: {integrity: sha512-vurkuzgac5SYuxd2HUZqAFAWGTF10diKBwJNbCvnWijNZfXd+7jMtqjPFbGt7idOJUn584fP1Ar9j/GN2jQ3Ew==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4260,13 +4271,13 @@ packages:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.20.12)
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.20.12)
-      vite: 4.1.1(@types/node@17.0.45)
+      vite: 4.1.5(@types/node@17.0.45)
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-vue-jsx@3.0.1(vite@4.2.0):
+  /@vitejs/plugin-vue-jsx@3.0.1(vite@4.2.3)(vue@3.2.47):
     resolution: {integrity: sha512-+Jb7ggL48FSPS1uhPnJbJwWa9Sr90vQ+d0InW+AhBM22n+cfuYqJZDckBc+W3QSHe1WDvewMZfa4wZOtk5pRgw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4279,31 +4290,31 @@ packages:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.21.4)
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.4)
-      vite: 4.2.0(@types/node@17.0.45)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@vitejs/plugin-vue-jsx@3.0.1(vite@4.2.1)(vue@3.2.47):
-    resolution: {integrity: sha512-+Jb7ggL48FSPS1uhPnJbJwWa9Sr90vQ+d0InW+AhBM22n+cfuYqJZDckBc+W3QSHe1WDvewMZfa4wZOtk5pRgw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.0.0 || ^2.9.0 || ^3.0.0
-      vue: '*'
-    peerDependenciesMeta:
-      vue:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.21.4)
-      '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.4)
-      vite: 4.2.1
+      vite: 4.2.3
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue2@2.2.0(vite@4.2.0)(vue@2.7.14):
+  /@vitejs/plugin-vue-jsx@3.0.1(vite@4.4.8):
+    resolution: {integrity: sha512-+Jb7ggL48FSPS1uhPnJbJwWa9Sr90vQ+d0InW+AhBM22n+cfuYqJZDckBc+W3QSHe1WDvewMZfa4wZOtk5pRgw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0 || ^2.9.0 || ^3.0.0
+      vue: '*'
+    peerDependenciesMeta:
+      vue:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.21.4)
+      '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.4)
+      vite: 4.4.8(@types/node@17.0.45)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@vitejs/plugin-vue2@2.2.0(vite@4.4.8)(vue@2.7.14):
     resolution: {integrity: sha512-1km7zEuZ/9QRPvzXSjikbTYGQPG86Mq1baktpC4sXqsXlb02HQKfi+fl8qVS703JM7cgm24Ga9j+RwKmvFn90A==}
     engines: {node: ^14.18.0 || >= 16.0.0}
     peerDependencies:
@@ -4313,11 +4324,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 4.2.0(@types/node@17.0.45)
+      vite: 4.4.8(@types/node@17.0.45)
       vue: 2.7.14
     dev: true
 
-  /@vitejs/plugin-vue@2.3.4(vite@2.9.15)(vue@3.2.47):
+  /@vitejs/plugin-vue@2.3.4(vite@4.4.8)(vue@3.2.47):
     resolution: {integrity: sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -4327,11 +4338,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 2.9.15
+      vite: 4.4.8(@types/node@17.0.45)
       vue: 3.2.47
     dev: true
 
-  /@vitejs/plugin-vue@3.2.0(vite@3.2.5)(vue@3.2.47):
+  /@vitejs/plugin-vue@3.2.0(vite@3.2.7)(vue@3.2.47):
     resolution: {integrity: sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4341,11 +4352,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 3.2.5(@types/node@17.0.45)
+      vite: 3.2.7(@types/node@17.0.45)
       vue: 3.2.47
     dev: true
 
-  /@vitejs/plugin-vue@4.0.0(vite@4.1.1)(vue@3.2.47):
+  /@vitejs/plugin-vue@4.0.0(vite@4.1.5)(vue@3.2.47):
     resolution: {integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4355,11 +4366,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 4.1.1(@types/node@17.0.45)
+      vite: 4.1.5(@types/node@17.0.45)
       vue: 3.2.47
     dev: false
 
-  /@vitejs/plugin-vue@4.0.0(vite@4.2.0)(vue@3.2.47):
+  /@vitejs/plugin-vue@4.0.0(vite@4.4.8)(vue@3.2.47):
     resolution: {integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4369,11 +4380,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 4.2.0(sass@1.58.0)
+      vite: 4.4.8(sass@1.58.0)
       vue: 3.2.47
     dev: true
 
-  /@vitejs/plugin-vue@4.1.0(vite@4.2.0):
+  /@vitejs/plugin-vue@4.1.0(vite@4.2.3)(vue@3.2.47):
     resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4383,22 +4394,22 @@ packages:
       vue:
         optional: true
     dependencies:
-      vite: 4.2.0(@types/node@17.0.45)
+      vite: 4.2.3
+      vue: 3.2.47
+    dev: true
+
+  /@vitejs/plugin-vue@4.1.0(vite@4.4.8):
+    resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0 || ^2.9.0 || ^3.0.0
+      vue: '*'
+    peerDependenciesMeta:
+      vue:
+        optional: true
+    dependencies:
+      vite: 4.4.8(@types/node@17.0.45)
     dev: false
-
-  /@vitejs/plugin-vue@4.1.0(vite@4.2.1)(vue@3.2.47):
-    resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.0.0 || ^2.9.0 || ^3.0.0
-      vue: '*'
-    peerDependenciesMeta:
-      vue:
-        optional: true
-    dependencies:
-      vite: 4.2.1
-      vue: 3.2.47
-    dev: true
 
   /@volar/language-core@1.0.24:
     resolution: {integrity: sha512-vTN+alJiWwK0Pax6POqrmevbtFW2dXhjwWiW/MW4f48eDYPLdyURWcr8TixO7EN/nHsUBj2udT7igFKPtjyAKg==}
@@ -4483,11 +4494,30 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
+  /@vue/compiler-core@3.3.4:
+    resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
+    requiresBuild: true
+    dependencies:
+      '@babel/parser': 7.22.7
+      '@vue/shared': 3.3.4
+      estree-walker: 2.0.2
+      source-map-js: 1.0.2
+    dev: true
+    optional: true
+
   /@vue/compiler-dom@3.2.47:
     resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
     dependencies:
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
+
+  /@vue/compiler-dom@3.3.4:
+    resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
+    dependencies:
+      '@vue/compiler-core': 3.3.4
+      '@vue/shared': 3.3.4
+    dev: true
+    optional: true
 
   /@vue/compiler-sfc@2.7.14:
     resolution: {integrity: sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==}
@@ -4584,11 +4614,24 @@ packages:
     dependencies:
       '@vue/shared': 3.2.47
 
+  /@vue/reactivity@3.3.4:
+    resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
+    dependencies:
+      '@vue/shared': 3.3.4
+    dev: true
+
   /@vue/runtime-core@3.2.47:
     resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
     dependencies:
       '@vue/reactivity': 3.2.47
       '@vue/shared': 3.2.47
+
+  /@vue/runtime-core@3.3.4:
+    resolution: {integrity: sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==}
+    dependencies:
+      '@vue/reactivity': 3.3.4
+      '@vue/shared': 3.3.4
+    dev: true
 
   /@vue/runtime-dom@3.2.47:
     resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
@@ -4596,6 +4639,14 @@ packages:
       '@vue/runtime-core': 3.2.47
       '@vue/shared': 3.2.47
       csstype: 2.6.21
+
+  /@vue/runtime-dom@3.3.4:
+    resolution: {integrity: sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==}
+    dependencies:
+      '@vue/runtime-core': 3.3.4
+      '@vue/shared': 3.3.4
+      csstype: 3.1.1
+    dev: true
 
   /@vue/server-renderer@3.2.47(vue@3.2.47):
     resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
@@ -4612,6 +4663,10 @@ packages:
   /@vue/shared@3.2.47:
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
 
+  /@vue/shared@3.3.4:
+    resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
+    dev: true
+
   /@vue/test-utils@2.2.10(vue@3.2.47):
     resolution: {integrity: sha512-UPY+VdWST5vYZ/Qhl+sLuJAv596e6kTbrOPgdGY82qd9kGN/MfjzLT5KXlmpChkiCbPP3abZ8XT25u1n5h+mRg==}
     peerDependencies:
@@ -4623,7 +4678,7 @@ packages:
       js-beautify: 1.14.6
       vue: 3.2.47
     optionalDependencies:
-      '@vue/compiler-dom': 3.2.47
+      '@vue/compiler-dom': 3.3.4
     dev: true
 
   /@vuetify/loader-shared@1.7.1(vue@3.2.47)(vuetify@3.1.3):
@@ -6697,6 +6752,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-64@0.15.18:
@@ -6714,6 +6770,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64@0.15.18:
@@ -6731,6 +6788,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64@0.15.18:
@@ -6748,6 +6806,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64@0.15.18:
@@ -6765,6 +6824,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64@0.15.18:
@@ -6782,6 +6842,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64@0.15.18:
@@ -6799,6 +6860,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32@0.15.18:
@@ -6816,6 +6878,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64@0.15.18:
@@ -6833,6 +6896,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64@0.15.18:
@@ -6850,6 +6914,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm@0.15.18:
@@ -6867,6 +6932,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le@0.15.18:
@@ -6884,6 +6950,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le@0.15.18:
@@ -6901,6 +6968,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64@0.15.18:
@@ -6918,6 +6986,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x@0.15.18:
@@ -6935,6 +7004,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64@0.15.18:
@@ -6952,6 +7022,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64@0.15.18:
@@ -6969,6 +7040,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64@0.15.18:
@@ -6986,6 +7058,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32@0.15.18:
@@ -7003,6 +7076,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64@0.15.18:
@@ -7020,6 +7094,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64@0.15.18:
@@ -7058,6 +7133,7 @@ packages:
       esbuild-windows-32: 0.14.54
       esbuild-windows-64: 0.14.54
       esbuild-windows-arm64: 0.14.54
+    dev: true
 
   /esbuild@0.15.18:
     resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
@@ -7147,36 +7223,35 @@ packages:
       '@esbuild/win32-arm64': 0.17.16
       '@esbuild/win32-ia32': 0.17.16
       '@esbuild/win32-x64': 0.17.16
-    dev: true
 
-  /esbuild@0.17.5:
-    resolution: {integrity: sha512-Bu6WLCc9NMsNoMJUjGl3yBzTjVLXdysMltxQWiLAypP+/vQrf+3L1Xe8fCXzxaECus2cEJ9M7pk4yKatEwQMqQ==}
+  /esbuild@0.18.19:
+    resolution: {integrity: sha512-ra3CaIKCzJp5bU5BDfrCc0FRqKj71fQi+gbld0aj6lN0ifuX2fWJYPgLVLGwPfA+ruKna+OWwOvf/yHj6n+i0g==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.5
-      '@esbuild/android-arm64': 0.17.5
-      '@esbuild/android-x64': 0.17.5
-      '@esbuild/darwin-arm64': 0.17.5
-      '@esbuild/darwin-x64': 0.17.5
-      '@esbuild/freebsd-arm64': 0.17.5
-      '@esbuild/freebsd-x64': 0.17.5
-      '@esbuild/linux-arm': 0.17.5
-      '@esbuild/linux-arm64': 0.17.5
-      '@esbuild/linux-ia32': 0.17.5
-      '@esbuild/linux-loong64': 0.17.5
-      '@esbuild/linux-mips64el': 0.17.5
-      '@esbuild/linux-ppc64': 0.17.5
-      '@esbuild/linux-riscv64': 0.17.5
-      '@esbuild/linux-s390x': 0.17.5
-      '@esbuild/linux-x64': 0.17.5
-      '@esbuild/netbsd-x64': 0.17.5
-      '@esbuild/openbsd-x64': 0.17.5
-      '@esbuild/sunos-x64': 0.17.5
-      '@esbuild/win32-arm64': 0.17.5
-      '@esbuild/win32-ia32': 0.17.5
-      '@esbuild/win32-x64': 0.17.5
+      '@esbuild/android-arm': 0.18.19
+      '@esbuild/android-arm64': 0.18.19
+      '@esbuild/android-x64': 0.18.19
+      '@esbuild/darwin-arm64': 0.18.19
+      '@esbuild/darwin-x64': 0.18.19
+      '@esbuild/freebsd-arm64': 0.18.19
+      '@esbuild/freebsd-x64': 0.18.19
+      '@esbuild/linux-arm': 0.18.19
+      '@esbuild/linux-arm64': 0.18.19
+      '@esbuild/linux-ia32': 0.18.19
+      '@esbuild/linux-loong64': 0.18.19
+      '@esbuild/linux-mips64el': 0.18.19
+      '@esbuild/linux-ppc64': 0.18.19
+      '@esbuild/linux-riscv64': 0.18.19
+      '@esbuild/linux-s390x': 0.18.19
+      '@esbuild/linux-x64': 0.18.19
+      '@esbuild/netbsd-x64': 0.18.19
+      '@esbuild/openbsd-x64': 0.18.19
+      '@esbuild/sunos-x64': 0.18.19
+      '@esbuild/win32-arm64': 0.18.19
+      '@esbuild/win32-ia32': 0.18.19
+      '@esbuild/win32-x64': 0.18.19
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -9808,6 +9883,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   /nanoid@4.0.1:
     resolution: {integrity: sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==}
     engines: {node: ^14 || ^16 || >=18}
@@ -9871,7 +9951,7 @@ packages:
       defu: 6.1.2
       destr: 1.2.2
       dot-prop: 7.2.0
-      esbuild: 0.17.5
+      esbuild: 0.17.16
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       fs-extra: 11.1.0
@@ -10205,6 +10285,7 @@ packages:
       - encoding
       - eslint
       - less
+      - lightningcss
       - meow
       - optionator
       - rollup
@@ -10282,6 +10363,7 @@ packages:
       - encoding
       - eslint
       - less
+      - lightningcss
       - meow
       - optionator
       - rollup
@@ -11431,6 +11513,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss@8.4.27:
+    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+
   /pragma@1.0.0:
     resolution: {integrity: sha512-oJ+eL72877Ynjq1N8mMwE51R5hBsYfnCpu1PpqexrngZWnOUHUC5YtxuPg5eZsLyoZEOwfwoyXlTjy694wjQRA==}
     dependencies:
@@ -11825,6 +11915,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
@@ -11843,6 +11934,14 @@ packages:
 
   /rollup@3.20.2:
     resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup@3.27.2:
+    resolution: {integrity: sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -13241,10 +13340,11 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.2.0(@types/node@17.0.45)
+      vite: 4.4.8(@types/node@17.0.45)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -13262,10 +13362,11 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.2.1
+      vite: 4.4.8(@types/node@17.0.45)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -13282,14 +13383,14 @@ packages:
       minimist: 1.2.7
       mlly: 0.4.3
       pathe: 0.2.0
-      vite: 2.9.15
+      vite: 2.9.16
     transitivePeerDependencies:
       - less
       - sass
       - stylus
     dev: true
 
-  /vite-plugin-checker@0.5.5(eslint@8.33.0)(typescript@4.9.5)(vite@4.1.1):
+  /vite-plugin-checker@0.5.5(eslint@8.33.0)(typescript@4.9.5)(vite@4.1.5):
     resolution: {integrity: sha512-BLaRlBmiVn3Fg/wR9A0+YNwgXVteFJaH8rCIiIgYQcQ50jc3oVe2m8i0xxG5geq36UttNJsAj7DpDelN7/KjOg==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -13334,14 +13435,14 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 4.9.5
-      vite: 4.1.1(@types/node@17.0.45)
+      vite: 4.1.5(@types/node@17.0.45)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
     dev: false
 
-  /vite-plugin-checker@0.5.6(eslint@8.33.0)(typescript@4.9.5)(vite@4.2.1):
+  /vite-plugin-checker@0.5.6(eslint@8.33.0)(typescript@4.9.5)(vite@4.2.3):
     resolution: {integrity: sha512-ftRyON0gORUHDxcDt2BErmsikKSkfvl1i2DoP6Jt2zDO9InfvM6tqO1RkXhSjkaXEhKPea6YOnhFaZxW3BzudQ==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -13386,14 +13487,14 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 4.9.5
-      vite: 4.2.1
+      vite: 4.2.3
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
     dev: true
 
-  /vite-plugin-vuetify@1.0.0-alpha.12(vite@2.9.15)(vue@3.2.47)(vuetify@3.1.3):
+  /vite-plugin-vuetify@1.0.0-alpha.12(vite@4.4.8)(vue@3.2.47)(vuetify@3.1.3):
     resolution: {integrity: sha512-DMb7oY6F67P1RTEU28xQePUnyZdm+sbeGgIF3exBrA5yLL8NKKPIahqJN4+MAWMXCJVwNKy7nsS6zVgOLtcoQg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -13402,14 +13503,14 @@ packages:
     dependencies:
       '@vuetify/loader-shared': 1.7.1(vue@3.2.47)(vuetify@3.1.3)
       debug: 4.3.4(supports-color@8.1.1)
-      vite: 2.9.15
+      vite: 4.4.8(@types/node@17.0.45)
       vuetify: 3.1.3(vite-plugin-vuetify@1.0.0-alpha.12)(vue@3.2.47)
     transitivePeerDependencies:
       - supports-color
       - vue
 
-  /vite@2.9.15:
-    resolution: {integrity: sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==}
+  /vite@2.9.16:
+    resolution: {integrity: sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -13425,14 +13526,15 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.21
+      postcss: 8.4.27
       resolve: 1.22.1
       rollup: 2.77.3
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
-  /vite@3.2.5(@types/node@17.0.45):
-    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
+  /vite@3.2.7(@types/node@17.0.45):
+    resolution: {integrity: sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -13458,15 +13560,15 @@ packages:
     dependencies:
       '@types/node': 17.0.45
       esbuild: 0.15.18
-      postcss: 8.4.21
+      postcss: 8.4.27
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.1.1(@types/node@17.0.45):
-    resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
+  /vite@4.1.5(@types/node@17.0.45):
+    resolution: {integrity: sha512-zJ0RiVkf61kpd7O+VtU6r766xgnTaIknP/lR6sJTZq3HtVJ3HGnTo5DaJhTUtYoTyS/CQwZ6yEVdc/lrmQT7dQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -13492,82 +13594,15 @@ packages:
     dependencies:
       '@types/node': 17.0.45
       esbuild: 0.16.17
-      postcss: 8.4.21
+      postcss: 8.4.27
       resolve: 1.22.1
-      rollup: 3.20.2
+      rollup: 3.27.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
 
-  /vite@4.2.0(@types/node@17.0.45):
-    resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 17.0.45
-      esbuild: 0.17.5
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.20.2
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  /vite@4.2.0(sass@1.58.0):
-    resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.17.5
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.20.2
-      sass: 1.58.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.2.1:
-    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
+  /vite@4.2.3:
+    resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -13592,14 +13627,85 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.17.16
-      postcss: 8.4.21
+      postcss: 8.4.27
       resolve: 1.22.1
-      rollup: 3.20.2
+      rollup: 3.27.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu@0.2.4(vite@4.2.0):
+  /vite@4.4.8(@types/node@17.0.45):
+    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 17.0.45
+      esbuild: 0.18.19
+      postcss: 8.4.27
+      rollup: 3.27.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@4.4.8(sass@1.58.0):
+    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.19
+      postcss: 8.4.27
+      rollup: 3.27.2
+      sass: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitefu@0.2.4(vite@4.4.8):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^2.9.0
@@ -13607,7 +13713,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.2.0(@types/node@17.0.45)
+      vite: 4.4.8(@types/node@17.0.45)
     dev: true
 
   /vitepress@1.0.0-alpha.10:
@@ -13616,12 +13722,12 @@ packages:
     dependencies:
       '@docsearch/css': 3.3.2
       '@docsearch/js': 3.3.2
-      '@vitejs/plugin-vue': 3.2.0(vite@3.2.5)(vue@3.2.47)
+      '@vitejs/plugin-vue': 3.2.0(vite@3.2.7)(vue@3.2.47)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 9.12.0(vue@3.2.47)
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.11.1
-      vite: 3.2.5(@types/node@17.0.45)
+      vite: 3.2.7(@types/node@17.0.45)
       vue: 3.2.47
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -13824,7 +13930,7 @@ packages:
       webpack-plugin-vuetify:
         optional: true
     dependencies:
-      vite-plugin-vuetify: 1.0.0-alpha.12(vite@2.9.15)(vue@3.2.47)(vuetify@3.1.3)
+      vite-plugin-vuetify: 1.0.0-alpha.12(vite@4.4.8)(vue@3.2.47)(vuetify@3.1.3)
       vue: 3.2.47
 
   /w3c-keyname@2.2.6:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When linking `vite` locally and running `pnpm test`. There's an error in `packages/histoire`:

```
 ERROR  Failed to load url esbuild (resolved id: esbuild). Does the file exist?                                                                              14:23:30

  at loadAndTransform (/Users/bjorn/Work/oss/vite/packages/vite/dist/node/chunks/dep-4650b0ed.js:54937:21)
  at async ViteNodeServer._transformRequest (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/vite-node@0.3.6/node_modules/vite-node/dist/server.js:197:16)
  at async ViteNodeServer._fetchModule (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/vite-node@0.3.6/node_modules/vite-node/dist/server.js:185:17)
  at async MessagePort.<anonymous> (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/@peeky+runner@0.14.0/node_modules/@peeky/runner/dist/message.js:35:32)
```

And an error in `packages/histoire-controls`:

```
 ERROR  Failed to load url @vue/runtime-dom (resolved id: @vue/runtime-dom). Does the file exist?                                                            14:16:42

  at loadAndTransform (/Users/bjorn/Work/oss/vite/packages/vite/dist/node/chunks/dep-4650b0ed.js:54937:21)
  at async ViteNodeServer._transformRequest (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/vite-node@0.3.6/node_modules/vite-node/dist/server.js:197:16)
  at async ViteNodeServer._fetchModule (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/vite-node@0.3.6/node_modules/vite-node/dist/server.js:185:17)
  at async MessagePort.<anonymous> (/Users/bjorn/Work/oss/histoire/node_modules/.pnpm/@peeky+runner@0.14.0/node_modules/@peeky/runner/dist/message.js:35:32)
```

This PR has a (lame) fix by adding `esbuild` as dev dep in `packages/histoire`, and `@vue/runtime-dom` as dev dep in `packages/histoire-controls`. Also updating `vite` to latest v4.4.8 (deduplicate esbuild version v0.18).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I tried to dig into the issue. I suspect it's peeky not loading modules right when linking packages locally (regardless `link:` or `file:`). The issue does not appear when upgrading Vite to latest itself, only errors when linking.

It reminded me of [this trick we had to do](https://github.com/vitejs/vite/blob/a1b519e2c71593b6b4286c2f0bd8bfe2e0ad046d/vitest.config.e2e.ts#L19-L22) in Vite for Vitest, and the closest config I found was [buildInclude](https://peeky.dev/guide/config.html#buildinclude) and [buildExclude](https://peeky.dev/guide/config.html#buildexclude). However they don't seem to be used by peeky itself.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
