### PR TITLE
fix(nuxt): don't stub out unenv

### DIFF
--- a/packages/histoire-plugin-nuxt/package.json
+++ b/packages/histoire-plugin-nuxt/package.json
@@ -30,7 +30,7 @@
     "@nuxt/kit": "^3.6.5",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
-    "h3": "^1.7.1",
+    "h3": "npm:h3-nightly",
     "ofetch": "^1.1.1",
     "unenv": "^1.7.1"
   },

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -88,25 +88,7 @@ export async function setupVue3 () {
       })
     },
 
-    onBuild (api) {
-      api.changeViteConfig(config => {
-        const emptyId = 'histoire-nuxt-empty'
-        config.plugins.push({
-          name: 'histoire-nuxt-ignore',
-          enforce: 'pre',
-          resolveId (id) {
-            if (id.includes('unenv')) {
-              return emptyId
-            }
-          },
-          load (id) {
-            if (id === emptyId) {
-              return 'export default {}'
-            }
-          },
-        })
-      })
-
+    onBuild () {
       nuxt?.close()
     },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,8 +654,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(vite@4.4.9)
       h3:
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.8.0-1692053509.7cebec2
       nuxt:
         specifier: ^3.0.0-rc.11
         version: 3.6.5(@types/node@17.0.45)(eslint@8.47.0)(typescript@4.9.5)
@@ -2563,7 +2563,6 @@ packages:
       - '@types/node'
       - eslint
       - less
-      - lightningcss
       - meow
       - optionator
       - rollup
@@ -7718,6 +7717,19 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
+  /h3-nightly@1.8.0-1692053509.7cebec2:
+    resolution: {integrity: sha512-iSEG1DygDYL/fgNylkLUsVFujuz8+vv+GVPLUNFK2VvISgs9N25E4n3Mnmhje+yoU6bgZ3GqOYU5geZnLz34mg==}
+    dependencies:
+      cookie-es: 1.0.0
+      defu: 6.1.2
+      destr: 2.0.1
+      iron-webcrypto: 0.8.0
+      radix3: 1.0.1
+      ufo: 1.2.0
+      uncrypto: 0.1.3
+      unenv: 1.7.1
+    dev: false
+
   /h3@1.7.1:
     resolution: {integrity: sha512-A9V2NEDNHet7v1gCg7CMwerSigLi0SRbhTy7C3lGb0N4YKIpPmLDjedTUopqp4dnn7COHfqUjjaz3zbtz4QduA==}
     dependencies:
@@ -9508,7 +9520,6 @@ packages:
       - eslint
       - idb-keyval
       - less
-      - lightningcss
       - meow
       - optionator
       - rollup
@@ -12362,11 +12373,10 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.3.9(@types/node@17.0.45)
     transitivePeerDependencies:
       - '@types/node'
       - less
-      - lightningcss
       - sass
       - stylus
       - sugarss


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In preparation for upcoming h3 1.8.0 release, this removes the unenv stub that we currently have in histoire. There may be some extra context I'm unaware of though in https://github.com/histoire-dev/histoire/pull/443 for why this is present. (I'm hoping the underlying reason has been addressed/resolved upstream since then.)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
