### PR TITLE
fix(tailwind): allow different fontSize configuration values

### DIFF
--- a/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
+++ b/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
@@ -239,8 +239,8 @@ export default {
       }, ({ token }) => h('div', {
         class: '__hst-truncate',
         style: {
-          fontSize: token.value[0],
-          ...token.value[1],
+          fontSize: Array.isArray(token.value) ? token.value[0] : token.value,
+          ...(Array.isArray(token.value) && typeof token.value[1] === "object" ? token.value[1] : { lineHeight: token.value[1] })
         },
       }, sampleText.value))),
       onMountControls: (api) => mountApp(api, () => [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes [an issue](https://github.com/histoire-dev/histoire/issues/391) where only one type of value is allowed for configuring `fontSize` in the Tailwind theme. Tailwind [supports](https://tailwindcss.com/docs/font-size#using-custom-values) the following values:

```js
module.exports = {
  theme: {
    fontSize: {
      sm: '0.8rem', // single value
      base: ['16px', '24px'], // [fontSize, lineHeight] tuple
      'lg': ['1.5rem', {
        lineHeight: '2rem',
        letterSpacing: '-0.01em',
        fontWeight: '500',
      }], // [fontSize, { lineHeight?, letterSpacing?, fontWeight? }] tuple
    }
  }
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
