### PR TITLE
fix(nuxt): disable nuxt app manifest

### DIFF
--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -125,6 +125,7 @@ async function useNuxtViteConfig () {
     overrides: {
       ssr: false,
       experimental: {
+        // @ts-expect-error coming in Nuxt v3.8
         appManifest: false,
       },
       app: {

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -124,6 +124,9 @@ async function useNuxtViteConfig () {
     dev: true,
     overrides: {
       ssr: false,
+      experimental: {
+        appManifest: false,
+      },
       app: {
         rootId: 'nuxt-test',
       },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is an advance fix for Nuxt v3.8, which ships with a new 'app manifest' feature that doesn't make sense in the context of `histoire`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
