### PR TITLE
chore(nuxt): temporarily move to `@ts-ignore`

### DIFF
--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -125,7 +125,7 @@ async function useNuxtViteConfig () {
     overrides: {
       ssr: false,
       experimental: {
-        // @ts-expect-error coming in Nuxt v3.8
+        // @ts-ignore coming in Nuxt v3.8
         appManifest: false,
       },
       app: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A tiny change to avoid failing Nuxt's ecosystem-ci before release of v3.8, so we can ensure histoire is working well with v3.8

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
