### PR TITLE
fix(nuxt): support multiple app presets

### DIFF
--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -150,7 +150,7 @@ async function useNuxtViteConfig () {
 
   nuxt.hook('imports:sources', presets => {
     const stubbedComposables = ['useNuxtApp']
-    for (const appPreset of presets.find(p => p.from.startsWith('#app'))) {
+    for (const appPreset of presets.filter(p => p.from.startsWith('#app'))) {
       appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || !stubbedComposables.includes(i))
     }
     presets.push({

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -150,8 +150,9 @@ async function useNuxtViteConfig () {
 
   nuxt.hook('imports:sources', presets => {
     const stubbedComposables = ['useNuxtApp']
-    const appPreset = presets.find(p => p.from === '#app')
-    appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || !stubbedComposables.includes(i))
+    for (const appPreset of presets.find(p => p.from.startsWith('#app'))) {
+      appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || !stubbedComposables.includes(i))
+    }
     presets.push({
       from: '#build/histoire/composables.mjs',
       imports: stubbedComposables,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A change coming in Nuxt 2.8.1, we now granularly inject composable auto-imports (https://github.com/nuxt/nuxt/pull/23951) so there is not a single app preset. The change in this PR should be backward compatible.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
