### PR TITLE
types: Fix keyboardShortcut param

### DIFF
--- a/packages/histoire-app/src/app/util/tooltip.ts
+++ b/packages/histoire-app/src/app/util/tooltip.ts
@@ -1,7 +1,7 @@
 import { isMac } from './env.js'
 import { formatKey } from './keyboard.js'
 
-export function makeTooltip (descriptionHtml: string, keyboardShortcut: ({ isMac: boolean }) => string) {
+export function makeTooltip (descriptionHtml: string, keyboardShortcut: (options: { isMac: boolean }) => string) {
   return {
     content: `<div>${descriptionHtml}</div><div class="htw-flex htw-items-center htw-gap-1 htw-mt-2 htw-text-sm">${genKeyboardShortcutHtml(keyboardShortcut({ isMac }))}</div>`,
     html: true,


### PR DESCRIPTION
### Description

Due to missing parameter name TS error appeared:
`'boolean' is an unused renaming of 'isMac'. Did you intend to use it as a type annotation?`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
