### PR TITLE
fix(hmr): Make HMR work with Nuxt

### DIFF
--- a/packages/histoire/src/node/server.ts
+++ b/packages/histoire/src/node/server.ts
@@ -33,8 +33,8 @@ export async function createServer (ctx: Context, options: CreateServerOptions =
     }
   }
 
-  const { server, viteConfigFile } = await getViteServer(false)
   const { server: nodeServer } = await getViteServer(true) // Should be run after the first one to get a fresh vite.config.js
+  const { server, viteConfigFile } = await getViteServer(false)
   await watchStories(ctx)
   const { stop: stopMdFileWatcher } = await createMarkdownFilesWatcher(ctx)
 

--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -80,7 +80,7 @@ export async function getViteConfigWithPlugins (isServer: boolean, ctx: Context)
   plugins.push({
     name: 'histoire-vite-plugin',
 
-    config () {
+    config (_, { command }) {
       return {
         resolve: {
           dedupe: [
@@ -134,7 +134,7 @@ export async function getViteConfigWithPlugins (isServer: boolean, ctx: Context)
           watch: {
             ignored: [`!**/node_modules/.histoire/**`, '**/vite.config.*'],
           },
-          hmr: !isServer,
+          hmr: command === 'build' ? false : !isServer,
         },
         define: {
           // We need to force this to be able to use `devtoolsRawSetupState`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #528 #445
HMR was not working with Nuxt (Vue3 however was able to do HMR). 

I'm not a Vite expert, so any help would be appreciated if I misinterpreted the way how histoire is working.
* Previously even for build command HMR was turned on for client builds. Using the `command === 'build'` check in build command HMR is turned off
* For dev builds ('serve'), two vite servers are being launched. First the "normal" one and second the "node server" I believe for collecting the stories. However for the node server HMR is disabled. I _believe_ this has disabled/interfered with the HMR of the first vite server. Changing the launch order makes HMR work for Nuxt as well.
 
### Additional context

If there is a better way to achieve the same, let me know.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
