### PR TITLE
fix: Consider platform specific CRLF when generating d.ts files

### DIFF
--- a/packages/histoire-vendors/rollup.config.mjs
+++ b/packages/histoire-vendors/rollup.config.mjs
@@ -29,13 +29,13 @@ export default defineConfig({
     }),
     {
       name: 'define',
-      transform (code) {
+      transform(code) {
         return code.replace(/__VUE_OPTIONS_API__/g, 'true')
       },
     },
     {
       name: 'process-build',
-      closeBundle () {
+      closeBundle() {
         try {
           const pkg = fs.readJsonSync('./package.json')
           const tempDir = path.resolve('./node_modules/.temp/histoire-vendors')
@@ -68,7 +68,7 @@ export default defineConfig({
               const filepath = file.replace(/\.d\.ts$/, '')
               const content = `import Default from '${filepath}'
 export default Default
-export * from '${filepath}'\n`
+export * from '${filepath}'\n`.replace(/\n/g, process.platform === 'win32' ? '\r\n' : '\n')
               fs.writeFileSync(path.basename(file).replace(/^b-/, ''), content, 'utf-8')
             }
             // Exports (package.json)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When building @histoire/vendors the generated `d.ts` files were saved with `\n` line endings. On Windows this resulted that these files were showing up as "changed". Using platform specific line endings solves this problem.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
