### PR TITLE
fix: Fix sandbox URL in getSandboxUrl function

### DIFF
--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,5 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  return `${base}/__sandbox.html?${url.toString()}`
+  const baseUrl = base === '/' ? base : base + '/'
+  return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,5 +6,5 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  return `${base}__sandbox.html?${url.toString()}`
+  return `${base}/__sandbox.html?${url.toString()}`
 }


### PR DESCRIPTION
Fixes #635

### Description

Vite's base attribute was not properly considered when generating URLs for stories in single / iframe layout.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
