### PR TITLE
fix: issue 426, add mock ResizeObserver to dom

### DIFF
--- a/packages/histoire/src/node/dom/env.ts
+++ b/packages/histoire/src/node/dom/env.ts
@@ -26,6 +26,13 @@ export function createDomEnv () {
     })
   }
 
+  window.ResizeObserver = window.ResizeObserver || class ResizeObserver {
+    constructor(cb: ResizeObserverCallback) {}
+    disconnect(): void {}
+    observe(target: Element, options?: ResizeObserverOptions): void {}
+    unobserve(target: Element): void {}
+  }
+
   return {
     window,
     destroy,

--- a/packages/histoire/src/node/dom/env.ts
+++ b/packages/histoire/src/node/dom/env.ts
@@ -27,10 +27,9 @@ export function createDomEnv () {
   }
 
   window.ResizeObserver = window.ResizeObserver || class ResizeObserver {
-    constructor(cb: ResizeObserverCallback) {}
-    disconnect(): void {}
-    observe(target: Element, options?: ResizeObserverOptions): void {}
-    unobserve(target: Element): void {}
+    disconnect (): void { /* noop */ }
+    observe (target: Element, options?: ResizeObserverOptions): void { /* noop */ }
+    unobserve (target: Element): void { /* noop */ }
   }
 
   return {


### PR DESCRIPTION
### Description
Add mock ResizeObserver to DOM after jsdom initialization to fix issue #426 

### Additional context

Using the `@formkit/autoanimate` module makes stories fail on load, since ResizeObserver is missing. The lib itself diligently checks if there is a window object available, before it tries to use it. I checked the relevant issue in Jsdom project ( https://github.com/jsdom/jsdom/issues/3368 ), but most use cases there seemed to be with testing. For those cases, it makes sense to add your own mock, if you want to trigger `observe` in a test. For us, however, it seems a simple noop replacement will do the trick. Hence this PR

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
