### PR TITLE
fix: Silent throw for state sync (fix #512)

### DIFF
--- a/packages/histoire-shared/src/state.ts
+++ b/packages/histoire-shared/src/state.ts
@@ -28,7 +28,11 @@ export function applyState (target: any, state: any, override = false) {
     if (!override && target[key] && !key.startsWith('_h') && typeof target[key] === 'object' && !Array.isArray(target[key])) {
       Object.assign(target[key], state[key])
     } else {
-      target[key] = state[key]
+      try {
+        target[key] = state[key]
+      } catch (e) {
+        // noop
+      }
     }
   }
 }


### PR DESCRIPTION
Fix #512 

### Description

We shouldn't sync computed state properties. However, I didn't find a proper way to detect if a prop is computed or not (IsReadonly doesn't seem to work).

I think it's okay to silently try/catch the setter, as computed should not be synced anyway.

### Additional context

If you have a better way of only skipping computed props, that would probably be better.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other