### PR TITLE
fix: Add a story root wrapper for Suspense (fix #677)

### DIFF
--- a/packages/histoire-plugin-vue/src/client/app/RenderStory.ts
+++ b/packages/histoire-plugin-vue/src/client/app/RenderStory.ts
@@ -118,8 +118,8 @@ export default _defineComponent({
             )
           }
 
-          // Wrap in Suspense to render async components
-          children.push(h(Suspense, {}, () => children.at(-1)))
+          children.push(h('div', children.at(-1)))
+          children.push(h(Suspense, {}, children.at(-1)))
 
           return children.at(-1)
         },

--- a/packages/histoire-plugin-vue/src/client/app/RenderStory.ts
+++ b/packages/histoire-plugin-vue/src/client/app/RenderStory.ts
@@ -118,7 +118,9 @@ export default _defineComponent({
             )
           }
 
+          // Wrap in div to ensure only one root element
           children.push(h('div', children.at(-1)))
+          // Wrap in Suspense to render async components
           children.push(h(Suspense, {}, children.at(-1)))
 
           return children.at(-1)


### PR DESCRIPTION
Fixes https://github.com/histoire-dev/histoire/issues/677

### Description

Added a root to present Suspense failing if there are several root to a story.

### Additional context

⚠️ I'm not quite sure why you would use a factory function for the last argument of the `h()` function...
I took the liberty of removing it, but if it was useful, I'll put it back!

ℹ️ The examples/vue3 project can't reproduce this error because it uses a global wrapper `addWrapper(WrapperGlobal)`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
