### PR TITLE
Support Svelte 5 preview

### DIFF
--- a/packages/histoire-plugin-svelte/package.json
+++ b/packages/histoire-plugin-svelte/package.json
@@ -61,6 +61,6 @@
   },
   "peerDependencies": {
     "histoire": "workspace:^",
-    "svelte": "^3.0.0 || ^4.0.0"
+    "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.0"
   }
 }


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

I want to play with Histoire and Svelte 5 preview but have to use `npm i --force` because Histoire doesn't support the package range. This should fix that.


### Additional context

self explanatory

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
