### PR TITLE
fix: getSandboxUrl when base="" served in subdirectory (fix #652,#635)

### DIFF
--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base == '/' || base == "" ? base : base + '/'
+  const baseUrl = base === '/' || base === "" ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base === '/' || base === '' ? base : base + '/'
+  const baseUrl = base.endsWith('/') ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base.endsWith('/') ? base : base + '/'
+  const baseUrl = base.endsWith('/') || base == "" ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base === '/' ? base : base + '/'
+  const baseUrl = base.endsWidth('/') ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base.endsWidth('/') ? base : base + '/'
+  const baseUrl = base === '/' || base === '' ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }

--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,6 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base.endsWith('/') || base == "" ? base : base + '/'
+  const baseUrl = base == '/' || base == "" ? base : base + '/'
   return `${baseUrl}__sandbox.html?${url.toString()}`
 }


### PR DESCRIPTION
This fixes issue when users use histoire using relative paths in a subdirectory.

Workaround is still ` <Story :layout="{ type: 'grid', width: '75%' }">` as mentioned in #635 

<!-- Thank you for contributing! -->

### Description

This enhances recent PR #652 that made break our histoire setup while using a relative path. We use base = "" however run it in a subfolder so adding the '/' actually breaks it, see image. When I fixed it in my local node_modules folder the code committed solved it.

### Additional context

N.B. I am using the nuxt extension. Without this fix I get the following error:

<img width="501" alt="image" src="https://github.com/histoire-dev/histoire/assets/120060/a26a8c6a-ac36-4354-8dd7-a24379300cac">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
