### PR TITLE
fix: revert "fix: Fix sandbox URL in getSandboxUrl function"

### DIFF
--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,5 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base === '/' ? base : base + '/'
-  return `${baseUrl}__sandbox.html?${url.toString()}`
+  return `${base}__sandbox.html?${url.toString()}`
 }


### PR DESCRIPTION
Reverts histoire-dev/histoire#652

## Description
Fix stories in iframes not showing when the base have a slash at the end.
## Additional context
The base url should have a slash at the start and at the end (every guides for configuring the base url have them, for example : https://vitejs.dev/config/shared-options.html#base)

If the base doesn't have the slash at the end, the build produce a bad result, it doesn't find js and css files because a slash is missing in the urls

