### PR TITLE
revert:  Fix sandbox URL in getSandboxUrl function

### DIFF
--- a/packages/histoire-app/src/app/util/sandbox.ts
+++ b/packages/histoire-app/src/app/util/sandbox.ts
@@ -6,6 +6,5 @@ export function getSandboxUrl (story: Story, variant: Variant) {
   const url = new URLSearchParams()
   url.append('storyId', story.id)
   url.append('variantId', variant.id)
-  const baseUrl = base === '/' ? base : base + '/'
-  return `${baseUrl}__sandbox.html?${url.toString()}`
+  return `${base}__sandbox.html?${url.toString()}`
 }


### PR DESCRIPTION
Reverts histoire-dev/histoire#652

After looking around (for example in vitepress), Vite's `base`  should be concatenated as-is like it was before the referenced PR.
