### PR TITLE
fix: StoryResponsivePreview full height

### DIFF
--- a/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
+++ b/packages/histoire-app/src/app/components/story/StoryResponsivePreview.vue
@@ -139,8 +139,9 @@ const sizeTooltip = computed(() => (responsiveWidth.value ?? 'Auto') + ' × ' + 
         class="htw-overflow-hidden htw-bg-white dark:htw-bg-gray-700 htw-rounded-lg htw-relative"
         :class="isResponsiveEnabled ? {
           'htw-w-fit': !!finalWidth,
-          'htw-h-fit': !!finalHeight
-        } : undefined"
+          'htw-h-fit': !!finalHeight,
+          'htw-h-full': !finalHeight
+        } : 'htw-h-full'"
       >
         <div
           class="bind-preview-bg htw-rounded-lg htw-h-full"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Re-add htw-h-full on a div of StoryResponsivePreview like before only when a height is not defined

<!-- ### Additional context -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [ ] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
