### PR TITLE
fix(plugin-nuxt): remove useNuxtApp mock in nuxt plugin preventing some behaviors (fix #703)

### DIFF
--- a/packages/histoire-plugin-nuxt/runtime/composables.mjs
+++ b/packages/histoire-plugin-nuxt/runtime/composables.mjs
@@ -1,1 +1,0 @@
-export const useNuxtApp = () => ({ runWithContext: async fn => await fn() })

--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -135,24 +135,12 @@ async function useNuxtViteConfig() {
   }
   const runtimeDir = fileURLToPath(new URL('../runtime', import.meta.url))
   nuxt.options.build.templates.push(
-    { src: join(runtimeDir, 'composables.mjs'), filename: 'histoire/composables.mjs' },
     { src: join(runtimeDir, 'components.mjs'), filename: 'histoire/components.mjs' },
   )
 
   nuxt.hook('app:templates', (app) => {
     app.templates = app.templates.filter(template => template.filename !== 'app-component.mjs')
     app.templates.push({ src: join(runtimeDir, 'app-component.mjs'), filename: 'app-component.mjs' })
-  })
-
-  nuxt.hook('imports:sources', (presets) => {
-    const stubbedComposables = ['useNuxtApp']
-    for (const appPreset of presets.filter(p => p.from?.startsWith('#app'))) {
-      appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || !stubbedComposables.includes(i))
-    }
-    presets.push({
-      from: '#build/histoire/composables.mjs',
-      imports: stubbedComposables,
-    })
   })
 
   return {


### PR DESCRIPTION
### Description
This PR fixes the issue #703. This bug comes from the useNuxtApp that is mocked in /packages/histoire-plugin-nuxt/runtime/composables.mjs 
It just removes this mock to use the useNuxtApp version from Nuxt. It allows some plugins that requires data from useNuxtApp to run correctly (e.g. @nuxtjs/i18n).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
