### PR TITLE
fix: Make ResponsivePreset.height Type Nullable

### DIFF
--- a/packages/histoire-shared/src/types/config.ts
+++ b/packages/histoire-shared/src/types/config.ts
@@ -19,7 +19,7 @@ export type GrayColorKeys = ColorKeys | '750' | '850' | '950'
 export interface ResponsivePreset {
   label: string
   width: number
-  height: number
+  height?: number
 }
 
 export interface BackgroundPreset {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

According to [the example config in the docs](https://histoire.dev/reference/config.html#responsivepresets) its possible to set `height: null` which currently results in an error:

<img width="492" alt="image" src="https://github.com/histoire-dev/histoire/assets/18698995/99c8d11c-0750-47af-9d77-fd8a6a63fd74">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
