### PR TITLE
fix: Handle ESM Tailwindconfigs (fix #667)

### DIFF
--- a/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
+++ b/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
@@ -28,7 +28,7 @@ export function tailwindTokens(options: TailwindTokensOptions = {}): Plugin {
       const { default: resolveConfig } = await import('tailwindcss/resolveConfig.js')
       const resolvedTailwindConfig = resolveConfig(tailwindConfig.default ?? tailwindConfig)
       const storyFile = api.path.resolve(api.pluginTempDir, 'Tailwind.story.js')
-      await api.fs.writeFile(storyFile, storyTemplate(resolvedTailwindConfig.default ?? resolvedTailwindConfig))
+      await api.fs.writeFile(storyFile, storyTemplate(resolvedTailwindConfig))
       api.addStoryFile(storyFile)
     }
     catch (e) {

--- a/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
+++ b/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
@@ -26,7 +26,7 @@ export function tailwindTokens(options: TailwindTokensOptions = {}): Plugin {
       await api.fs.writeFile(api.path.resolve(api.pluginTempDir, 'style.css'), css)
       const tailwindConfig = await api.moduleLoader.loadModule(tailwindConfigFile)
       const { default: resolveConfig } = await import('tailwindcss/resolveConfig.js')
-      const resolvedTailwindConfig = resolveConfig(tailwindConfig)
+      const resolvedTailwindConfig = resolveConfig(tailwindConfig.default ?? tailwindConfig)
       const storyFile = api.path.resolve(api.pluginTempDir, 'Tailwind.story.js')
       await api.fs.writeFile(storyFile, storyTemplate(resolvedTailwindConfig.default ?? resolvedTailwindConfig))
       api.addStoryFile(storyFile)

--- a/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
+++ b/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
@@ -28,7 +28,7 @@ export function tailwindTokens(options: TailwindTokensOptions = {}): Plugin {
       const { default: resolveConfig } = await import('tailwindcss/resolveConfig.js')
       const resolvedTailwindConfig = resolveConfig(tailwindConfig)
       const storyFile = api.path.resolve(api.pluginTempDir, 'Tailwind.story.js')
-      await api.fs.writeFile(storyFile, storyTemplate(resolvedTailwindConfig))
+      await api.fs.writeFile(storyFile, storyTemplate(resolvedTailwindConfig.default ?? resolvedTailwindConfig))
       api.addStoryFile(storyFile)
     }
     catch (e) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #667

When using ESMs `export default` instead of `module.exports` in `tailwind.config.{js,ts}` the tailwindConfig is nested in a `default` key which then incorrectly merges with tailwinds default config like this:

<img width="272" alt="image" src="https://github.com/histoire-dev/histoire/assets/18698995/e07e099e-0f55-4a5a-8ac1-b64328ad96a6">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
