### PR TITLE
fix: issue 407, add IntersectionObserver mock to Dom

### DIFF
--- a/packages/histoire/src/node/dom/env.ts
+++ b/packages/histoire/src/node/dom/env.ts
@@ -37,7 +37,7 @@ export function createDomEnv() {
     rootMargin: string
     thresholds: number[]
     disconnect(): void { /* noop */ }
-    observe(_target: Element): void { /* noop */  }
+    observe = (_target: Element) => void { /* noop */  }
     unobserve(_target: Element): void { /* noop */ }
     takeRecords(): IntersectionObserverEntry[] { return [] }
     }


### PR DESCRIPTION
### Description

Add mock ResizeObserver to DOM after jsdom initialisation to fix https://github.com/histoire-dev/histoire/issues/407. jsdom does not implement IntersectionObserver so we mock it.

### Additional context

I stumbled onto this issue when using nk-o/jarallax in a component, which uses IntersectionObserver and breaks histoire stories. There is an open issue on jsdom here: https://github.com/jsdom/jsdom/issues/2032 but looks like a won't fix due to the project's scope. This is a quick noop fix similar to (and indeed based on)
https://github.com/histoire-dev/histoire/commit/2d16838cc429b39ae1268a998eb3850d90c37074 / https://github.com/histoire-dev/histoire/pull/664

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
