### PR TITLE
fix: #709 render component controls prop only for valid types

### DIFF
--- a/examples/vue3-vuetify/src/components/v-btn.story.vue
+++ b/examples/vue3-vuetify/src/components/v-btn.story.vue
@@ -6,18 +6,20 @@ const text = ref('Click me!')
 </script>
 
 <template>
-  <Story>
-    <v-btn
-      @click="logEvent('click', $event)"
-    >
-      {{ text }}
-    </v-btn>
+  <Story :layout="{ type: 'grid', width: 200 }">
+    <Variant title="default">
+      <v-btn :active="false" @click="logEvent('click', $event)">
+        {{ text }}
+      </v-btn>
+    </Variant>
+    <Variant title="primary">
+      <v-btn color="primary" :active="false" @click="logEvent('click', $event)">
+        {{ text }}
+      </v-btn>
+    </Variant>
 
     <template #controls>
-      <HstText
-        v-model="text"
-        title="Default slot"
-      />
+      <HstText v-model="text" title="Default slot" />
     </template>
   </Story>
 </template>

--- a/packages/histoire-app/src/app/components/panel/ControlsComponentPropItem.vue
+++ b/packages/histoire-app/src/app/components/panel/ControlsComponentPropItem.vue
@@ -20,8 +20,9 @@ const comp = computed(() => {
     case 'boolean':
       return HstCheckbox
     case 'object':
-    default:
       return HstJson
+    default:
+      return null
   }
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This fixes the issue if the component prop is not valid types `string | number | boolean | object` . Some vuetify components have  prop type of `symbol` which is not valid for histoire controls. (unless we want to support it).

### Additional context

https://github.com/histoire-dev/histoire/issues/709

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
