### PR TITLE
feat: add host config to histoire dev

### DIFF
--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev:hst": "nodemon --watch ../../packages/histoire/dist --watch ../../packages/histoire-plugin-vue/dist --exec \"rm -rf ./node_modules/.hst* && HISTOIRE_DEV=true histoire dev\"",
-    "story:dev": "histoire dev",
+    "story:dev": "histoire dev --host",
     "story:build": "histoire build",
     "story:preview": "histoire preview --port 4567",
     "ci": "start-server-and-test story:preview http://localhost:4567/ test",

--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev:hst": "nodemon --watch ../../packages/histoire/dist --watch ../../packages/histoire-plugin-vue/dist --exec \"rm -rf ./node_modules/.hst* && HISTOIRE_DEV=true histoire dev\"",
-    "story:dev": "histoire dev --host",
+    "story:dev": "histoire dev",
     "story:build": "histoire build",
     "story:preview": "histoire preview --port 4567",
     "ci": "start-server-and-test story:preview http://localhost:4567/ test",

--- a/packages/histoire/src/node/bin.ts
+++ b/packages/histoire/src/node/bin.ts
@@ -18,6 +18,7 @@ program.command('dev')
   .option('-p, --port <port>', 'Listening port of the server')
   .option('-c, --config <file>', `[string] use specified config file`)
   .option('--open', 'Open in your default browser')
+  .option('--host <host>', '[string] specify hostname')
   .action(async (options) => {
     const { devCommand } = await import('./commands/dev.js')
     return devCommand(options)

--- a/packages/histoire/src/node/commands/dev.ts
+++ b/packages/histoire/src/node/commands/dev.ts
@@ -7,6 +7,7 @@ import { createServer } from '../server.js'
 export interface DevOptions {
   port: number
   open?: boolean
+  host?: string | boolean
   config?: string
 }
 
@@ -21,6 +22,7 @@ export async function devCommand(options: DevOptions) {
     const { server, viteConfigFile, close } = await createServer(ctx, {
       port: options.port,
       open: options.open,
+      host: options.host,
     })
     server.printUrls()
 

--- a/packages/histoire/src/node/server.ts
+++ b/packages/histoire/src/node/server.ts
@@ -15,14 +15,21 @@ import { createMarkdownFilesWatcher, onMarkdownListChange } from './markdown.js'
 export interface CreateServerOptions {
   port?: number
   open?: boolean
+  host?: string | boolean
 }
 
 export async function createServer(ctx: Context, options: CreateServerOptions = {}) {
   const getViteServer = async (collecting: boolean) => {
     const { viteConfig, viteConfigFile } = await getViteConfigWithPlugins(collecting, ctx)
 
-    if (!collecting && options.open) {
-      viteConfig.server.open = true
+    if (!collecting) {
+      if (options.open) {
+        viteConfig.server.open = true
+      }
+
+      if (options.host) {
+        viteConfig.server.host = options.host
+      }
     }
 
     const server = await createViteServer(viteConfig)


### PR DESCRIPTION
### Description
When I ssh remote development, I need it to be able to expose the service to the LAN to facilitate my debugging

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

