### PR TITLE
fix(dev): Tailwind story not generated on starting dev server

### DIFF
--- a/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
+++ b/packages/histoire/src/node/builtin-plugins/tailwind-tokens.ts
@@ -66,6 +66,8 @@ export function tailwindTokens(options: TailwindTokensOptions = {}): Plugin {
 
     onDev(api, onCleanup) {
       if (tailwindConfigFile) {
+        generate(api)
+        
         const watcher = api.watcher.watch(tailwindConfigFile)
           .on('change', () => generate(api))
           .on('add', () => generate(api))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes issue when starting the dev server, the Tailwind story is not generated until a change happens in the tailwind.config.* file.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other