### PR TITLE
feat: disable optimizer in vite-node for vite 6 compat

### DIFF
--- a/packages/histoire/src/node/build.ts
+++ b/packages/histoire/src/node/build.ts
@@ -50,7 +50,11 @@ export async function build(ctx: Context) {
   }
 
   const { viteConfig } = await getViteConfigWithPlugins(true, ctx)
-  const server = await createViteServer(viteConfig)
+  const server = await createViteServer(
+    mergeViteConfig(viteConfig, {
+      optimizeDeps: { include: [], noDiscovery: true },
+    }),
+  )
   await server.pluginContainer.buildStart({})
 
   const moduleLoader = useModuleLoader({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds `optimizeDeps.include = []` and `optimizeDeps.noDiscovery = true` when using vite-node to make histoire pass the tests with Vite with the Environment API PR merged (https://github.com/vitejs/vite/pull/16471).

Setting these options is [recommended by vite-node](https://github.com/vitest-dev/vitest/blob/v0.34.6/packages/vite-node/README.md#programmatic-usage). (`optimizeDeps.disable` is now [deprecated and replaced with the options above](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-disabled).)

`optimizeDeps.noDiscovery` was added in Vite 5.1, but given that histoire works without that setting for Vite pre-6, using it should be fine.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
