### PR TITLE
chore: set `cssFilename` to make ecosystem-ci pass

### DIFF
--- a/packages/histoire-app/vite.config.ts
+++ b/packages/histoire-app/vite.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
     lib: {
       entry: '',
       formats: ['es'],
+      // eslint-disable-next-line ts/prefer-ts-expect-error
+      // @ts-ignore only exists in Vite 6
+      cssFileName: 'style',
     },
     rollupOptions: {
       external: [

--- a/packages/histoire-controls/vite.config.ts
+++ b/packages/histoire-controls/vite.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
         'es',
       ],
       fileName: 'index.es',
+      // eslint-disable-next-line ts/prefer-ts-expect-error
+      // @ts-ignore only exists in Vite 6
+      cssFileName: 'style',
     },
 
     rollupOptions: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite 6 now aligns the CSS file name with the JS file name for lib mode (https://github.com/vitejs/vite/pull/18488).
I set `cssFilename` to make the repo compatible with Vite 6 and pass the ecosystem-ci (only partially as vite-plugin-svelte for Vite v6 is not released yet).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
