### PR TITLE
fix(nuxt): do not auto-import idle callback polyfills

### DIFF
--- a/packages/histoire-plugin-nuxt/src/index.ts
+++ b/packages/histoire-plugin-nuxt/src/index.ts
@@ -145,9 +145,10 @@ async function useNuxtViteConfig() {
   })
 
   nuxt.hook('imports:sources', (presets) => {
+    const polyfills = ['requestIdleCallback', 'cancelIdleCallback']
     const stubbedComposables = ['useNuxtApp']
     for (const appPreset of presets.filter(p => p.from?.startsWith('#app'))) {
-      appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || !stubbedComposables.includes(i))
+      appPreset.imports = appPreset.imports.filter(i => typeof i !== 'string' || (!stubbedComposables.includes(i) && !polyfills.includes(i)))
     }
     presets.push({
       from: '#build/histoire/composables.mjs',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Not quite sure why/when this popped up but noticed it failing in CI.

We hope to add an option to more easily configure this in Nuxt itself via https://github.com/nuxt/nuxt/pull/30332.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
