### PR TITLE
feat: Add plugin API hook vitePlugins

### DIFF
--- a/packages/histoire-shared/src/types/plugin.ts
+++ b/packages/histoire-shared/src/types/plugin.ts
@@ -2,7 +2,7 @@ import type chokidar from 'chokidar'
 import type fs from 'fs-extra'
 import type path from 'pathe'
 import type pc from 'picocolors'
-import type { InlineConfig as ViteInlineConfig } from 'vite'
+import type { InlineConfig as ViteInlineConfig, Plugin as VitePlugin } from 'vite'
 import type { Awaitable } from '../type-utils.js'
 import type {
   PluginCommand,
@@ -128,4 +128,8 @@ export interface Plugin {
    * Handle a custom event from the client in development mode.
    */
   onDevEvent?: (api: PluginApiDevEvent) => Awaitable<any>
+  /**
+   * Use this hook to manipulate Vite plugins before they are passed to Vite.
+   */
+  vitePlugins?: (plugins: VitePlugin[]) => void
 }

--- a/packages/histoire-shared/src/types/plugin.ts
+++ b/packages/histoire-shared/src/types/plugin.ts
@@ -131,5 +131,5 @@ export interface Plugin {
   /**
    * Use this hook to manipulate Vite plugins before they are passed to Vite.
    */
-  vitePlugins?: (plugins: VitePlugin[]) => void
+  vitePlugins?: (plugins: VitePlugin[]) => Awaitable<void>
 }

--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -342,11 +342,11 @@ export async function getViteConfigWithPlugins(isServer: boolean, ctx: Context):
     })
   }
 
-  ctx.config.plugins.forEach((plugin) => {
+  for (const plugin of ctx.config.plugins) {
     if (plugin.vitePlugins) {
-      plugin.vitePlugins(plugins)
+      await plugin.vitePlugins(plugins)
     }
-  })
+  }
 
   const viteConfig = mergeViteConfig(inlineConfig, {
     configFile: false,

--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -342,6 +342,12 @@ export async function getViteConfigWithPlugins(isServer: boolean, ctx: Context):
     })
   }
 
+  ctx.config.plugins.forEach((plugin) => {
+    if (plugin.vitePlugins) {
+      plugin.vitePlugins(plugins)
+    }
+  })
+
   const viteConfig = mergeViteConfig(inlineConfig, {
     configFile: false,
     plugins,


### PR DESCRIPTION
### Description

The goal is to allow the injection of vite plugin for histoire. For example, if I want to manipulate the head of the page before the module is mounted.

Example:
```ts
{
  name: 'inject-plugin',
  vitePlugins(plugins) {
    plugins.push({
      name: 'html-transform',
      transformIndexHtml(html) {
        return html.replace(
          /<title>(.*?)<\/title>/,
          `<title>Title replaced!</title>`,
        )
      },
    })
  },
}
```

Note: The particular usecase I'm thinking of, is to be able to inject importmap before module load.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
