### PR TITLE
types: Update `histoire-plugin-vue` to expose `components.d.ts`

### DIFF
--- a/packages/histoire-plugin-vue/package.json
+++ b/packages/histoire-plugin-vue/package.json
@@ -24,6 +24,9 @@
       "types": "./dist/client/server.d.ts",
       "default": "./dist/bundled/client/server.js"
     },
+    "./components": {
+      "types": "./components.d.ts"
+    },
     "./client-dev": {
       "default": "./src/client/client.ts"
     },


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Using triple-slash TS directives like
```ts
/// <reference types="@histoire/plugin-vue/components" />
```

is not working with my repo and its inclusion of Histoire because the components definition file is not explicitly exposed in the `@histoire/plugin-vue` library's package.json. These component types are also not exposed via the default type export (`./dist/index.node.d.ts`), so they are unable to be referenced in modern repo setups. This change rectifies that issue.

#### Before

<img width="727" height="138" alt="image" src="https://github.com/user-attachments/assets/1c289121-c7b7-43f0-b09f-a09549f63180" />

<img width="601" height="69" alt="image" src="https://github.com/user-attachments/assets/4a7ae169-d2ad-491a-8265-6b610405ec81" />

#### After

<img width="991" height="172" alt="image" src="https://github.com/user-attachments/assets/183e9099-df71-4b0b-a367-40c7ed7142f6" />

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
