### PR TITLE
feat: implement HstDate input

### DIFF
--- a/packages/histoire-controls/src/components/date/HstDate.spec.ts
+++ b/packages/histoire-controls/src/components/date/HstDate.spec.ts
@@ -1,0 +1,237 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import HstDate from './HstDate.vue'
+
+describe('hstDate', () => {
+  describe('basic functionality', () => {
+    it('renders with modelValue', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: new Date('2024-12-25'),
+        },
+      })
+
+      const input = wrapper.find('input')
+      expect(input.element.value).toBe('2024-12-25')
+    })
+
+    it('renders title', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          title: 'Select Date',
+        },
+      })
+
+      const hstWrapper = wrapper.findComponent({ name: 'HstWrapper' })
+      expect(hstWrapper.exists()).toBe(true)
+      expect(hstWrapper.props('title')).toBe('Select Date')
+    })
+  })
+
+  describe('input handling', () => {
+    it('emits update:modelValue and update:dateString on input', async () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+      })
+
+      const input = wrapper.find('input')
+      input.element.value = '2024-12-25'
+      await input.trigger('input')
+
+      expect(wrapper.emitted('update:dateString')).toHaveLength(1)
+      expect(wrapper.emitted('update:dateString')?.[0]).toEqual(['2024-12-25'])
+
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+      const emittedDate = wrapper.emitted('update:modelValue')?.[0][0] as Date
+      expect(emittedDate).toBeInstanceOf(Date)
+      expect(emittedDate.toISOString()).toMatchInlineSnapshot('"2024-12-25T00:00:00.000Z"')
+    })
+
+    it('emits empty string and null when clearing input', async () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: new Date('2024-12-25'),
+        },
+      })
+
+      const input = wrapper.find('input')
+      input.element.value = ''
+      await input.trigger('input')
+
+      expect(wrapper.emitted('update:dateString')).toHaveLength(1)
+      expect(wrapper.emitted('update:dateString')?.[0]).toEqual([''])
+
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([null])
+    })
+  })
+
+  describe('datetime prop', () => {
+    it('uses datetime-local input type when datetime is true', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          datetime: true,
+          modelValue: new Date('2024-12-25T14:30'),
+        },
+      })
+      const input = wrapper.find('input')
+      expect(input.element.type).toBe('datetime-local')
+    })
+
+    it('formats datetime-local correctly', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          datetime: true,
+          modelValue: new Date('2024-12-25T14:30:00.000Z'),
+        },
+      })
+      const input = wrapper.find('input')
+      expect(input.element.value).toMatchInlineSnapshot('"2024-12-25T14:30"')
+    })
+
+    it('uses date input type when datetime is false', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          datetime: false,
+          modelValue: new Date('2024-12-25'),
+        },
+      })
+      const input = wrapper.find('input')
+      expect(input.element.type).toBe('date')
+    })
+  })
+
+  describe('modelValue initialization', () => {
+    it('initializes input from modelValue', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: new Date('2024-12-25'),
+        },
+      })
+
+      const input = wrapper.find('input')
+      expect(input.element.value).toBe('2024-12-25')
+    })
+
+    it('initializes with empty string when modelValue is null', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+      })
+
+      const input = wrapper.find('input')
+      expect(input.element.value).toBe('')
+    })
+  })
+
+  describe('input change emissions', () => {
+    it('emits both dateString and modelValue on input change', async () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: new Date('2024-12-25'),
+        },
+      })
+
+      const input = wrapper.find('input')
+      input.element.value = '2024-12-26'
+      await input.trigger('input')
+
+      expect(wrapper.emitted('update:dateString')).toHaveLength(1)
+      expect(wrapper.emitted('update:dateString')?.[0]).toEqual(['2024-12-26'])
+
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+      const emittedDate = wrapper.emitted('update:modelValue')?.[0][0] as Date
+      expect(emittedDate.toISOString()).toMatchInlineSnapshot('"2024-12-26T00:00:00.000Z"')
+    })
+
+    it('emits with valid date string', async () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+      })
+
+      const input = wrapper.find('input')
+      input.element.value = '2024-12-20'
+      await input.trigger('input')
+
+      expect(wrapper.emitted('update:dateString')).toHaveLength(1)
+      expect(wrapper.emitted('update:dateString')?.[0]).toEqual(['2024-12-20'])
+
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+      const emittedDate = wrapper.emitted('update:modelValue')?.[0][0] as Date
+      expect(emittedDate.toISOString()).toMatchInlineSnapshot('"2024-12-20T00:00:00.000Z"')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles null modelValue', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+      })
+      const input = wrapper.find('input')
+      expect(input.element.value).toBe('')
+    })
+
+    it('handles undefined modelValue', () => {
+      const wrapper = mount(HstDate, {
+        props: {},
+      })
+      const input = wrapper.find('input')
+      expect(input.element.value).toBe('')
+    })
+
+    it('emits empty string and null for empty input', async () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+      })
+      const input = wrapper.find('input')
+      input.element.value = ''
+      await input.trigger('input')
+
+      expect(wrapper.emitted('update:dateString')).toHaveLength(1)
+      expect(wrapper.emitted('update:dateString')?.[0]).toEqual([''])
+
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([null])
+    })
+  })
+
+  describe('attributes and styling', () => {
+    it('accepts and applies arbitrary attributes', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+        attrs: {
+          placeholder: 'Pick a date',
+        },
+      })
+
+      const input = wrapper.find('input')
+      expect(input.element.placeholder).toBe('Pick a date')
+    })
+  })
+
+  describe('slot support', () => {
+    it('renders actions slot', () => {
+      const wrapper = mount(HstDate, {
+        props: {
+          modelValue: null,
+        },
+        slots: {
+          actions: '<button>Clear</button>',
+        },
+      })
+
+      expect(wrapper.html()).toContain('<button>Clear</button>')
+    })
+  })
+})

--- a/packages/histoire-controls/src/components/date/HstDate.story.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.story.vue
@@ -1,0 +1,63 @@
+<script lang="ts" setup>
+import HstDate from './HstDate.vue'
+
+function initState() {
+  return {
+    label: 'My really long label',
+    text: '',
+  }
+}
+</script>
+
+<template>
+  <Story
+    title="HstDate"
+    group="controls"
+    :layout="{
+      type: 'grid',
+      width: '100%',
+    }"
+  >
+    <Variant
+      title="default"
+      :init-state="initState"
+    >
+      <template #default="{ state }">
+        <HstDate
+          v-model="state.text"
+          :title="state.label"
+        />
+      </template>
+
+      <template #controls="{ state }">
+        <HstDate
+          v-model="state.label"
+          title="Label"
+        />
+        <HstDate
+          v-model="state.text"
+          title="Text"
+        />
+      </template>
+    </Variant>
+
+    <Variant
+      title="no-label"
+      :init-state="initState"
+    >
+      <template #default="{ state }">
+        <HstDate
+          v-model="state.text"
+          placeholder="Enter some text..."
+        />
+      </template>
+
+      <template #controls="{ state }">
+        <HstDate
+          v-model="state.text"
+          title="Text"
+        />
+      </template>
+    </Variant>
+  </Story>
+</template>

--- a/packages/histoire-controls/src/components/date/HstDate.story.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.story.vue
@@ -30,7 +30,7 @@ function initState() {
             v-model="state.date"
             :title="state.label"
             :datetime="state.datetime"
-            @update:date-string="state.dateText = $event"
+            @input="state.dateText = $event.target.value"
           />
           <div class="text-sm text-gray-600 space-y-1">
             <p>Date object: {{ state.date instanceof Date ? state.date.toISOString() : 'null' }}</p>
@@ -65,7 +65,7 @@ function initState() {
           <HstDate
             v-model="state.date"
             :datetime="state.datetime"
-            @update:date-string="state.dateText = $event"
+            @input="state.dateText = $event.target.value"
           />
           <div class="text-sm text-gray-600 space-y-1">
             <p>Date object: {{ state.date instanceof Date ? state.date.toISOString() : 'null' }}</p>

--- a/packages/histoire-controls/src/components/date/HstDate.story.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.story.vue
@@ -4,7 +4,9 @@ import HstDate from './HstDate.vue'
 function initState() {
   return {
     label: 'My really long label',
-    text: '',
+    date: new Date(),
+    dateText: '',
+    datetime: true,
   }
 }
 </script>
@@ -23,20 +25,33 @@ function initState() {
       :init-state="initState"
     >
       <template #default="{ state }">
-        <HstDate
-          v-model="state.text"
-          :title="state.label"
-        />
+        <div class="space-y-4">
+          <HstDate
+            v-model="state.date"
+            :title="state.label"
+            :datetime="state.datetime"
+            @update:date-string="state.dateText = $event"
+          />
+          <div class="text-sm text-gray-600 space-y-1">
+            <p>Date object: {{ state.date instanceof Date ? state.date.toISOString() : 'null' }}</p>
+            <p>String value: {{ state.dateText || '(empty)' }}</p>
+          </div>
+        </div>
       </template>
 
       <template #controls="{ state }">
-        <HstDate
+        <HstText
           v-model="state.label"
           title="Label"
         />
-        <HstDate
-          v-model="state.text"
+        <HstText
+          v-model="state.dateText"
           title="Text"
+        />
+
+        <HstCheckbox
+          v-model="state.datetime"
+          title="Date time"
         />
       </template>
     </Variant>
@@ -46,15 +61,22 @@ function initState() {
       :init-state="initState"
     >
       <template #default="{ state }">
-        <HstDate
-          v-model="state.text"
-          placeholder="Enter some text..."
-        />
+        <div class="space-y-4">
+          <HstDate
+            v-model="state.date"
+            :datetime="state.datetime"
+            @update:date-string="state.dateText = $event"
+          />
+          <div class="text-sm text-gray-600 space-y-1">
+            <p>Date object: {{ state.date instanceof Date ? state.date.toISOString() : 'null' }}</p>
+            <p>String value: {{ state.dateText || '(empty)' }}</p>
+          </div>
+        </div>
       </template>
 
       <template #controls="{ state }">
-        <HstDate
-          v-model="state.text"
+        <HstText
+          v-model="state.dateText"
           title="Text"
         />
       </template>

--- a/packages/histoire-controls/src/components/date/HstDate.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.vue
@@ -11,19 +11,15 @@ import HstWrapper from '../HstWrapper.vue'
 const props = defineProps<{
   title?: string
   datetime?: boolean
-  modelValue?: Date | null
 }>()
 
-const emit = defineEmits({
-  'update:modelValue': (newValue: Date | null) => true,
-  'update:dateString': (newValue: string) => true,
-})
+const dateModel = defineModel<Date | null>({ default: null })
 
 let initialValue = ''
-if (props.modelValue instanceof Date) {
+if (dateModel.value instanceof Date) {
   initialValue = props.datetime
-    ? props.modelValue.toISOString().slice(0, 16)
-    : props.modelValue.toISOString().slice(0, 10)
+    ? dateModel.value.toISOString().slice(0, 16)
+    : dateModel.value.toISOString().slice(0, 10)
 }
 const inputValue = ref(initialValue)
 const input = ref<HTMLInputElement>()
@@ -40,9 +36,8 @@ function stringToDate(str: string): Date | null {
 function onInputUpdate(event: Event) {
   const value = (event.target as HTMLInputElement).value
   inputValue.value = value
-  emit('update:dateString', value)
   const date = stringToDate(value)
-  emit('update:modelValue', date)
+  dateModel.value = date
 }
 </script>
 

--- a/packages/histoire-controls/src/components/date/HstDate.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.vue
@@ -5,19 +5,45 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import HstWrapper from '../HstWrapper.vue'
 
-defineProps<{
+const props = defineProps<{
   title?: string
-  modelValue?: string | null
+  datetime?: boolean
+  modelValue?: Date | null
 }>()
 
 const emit = defineEmits({
-  'update:modelValue': (newValue: string) => true,
+  'update:modelValue': (newValue: Date | null) => true,
+  'update:dateString': (newValue: string) => true,
 })
 
+let initialValue = ''
+if (props.modelValue instanceof Date) {
+  initialValue = props.datetime
+    ? props.modelValue.toISOString().slice(0, 16)
+    : props.modelValue.toISOString().slice(0, 10)
+}
+const inputValue = ref(initialValue)
 const input = ref<HTMLInputElement>()
+
+const dateType = computed(() => {
+  return props.datetime ? 'datetime-local' : 'date'
+})
+
+function stringToDate(str: string): Date | null {
+  const date = new Date(str)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function onInputUpdate(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  inputValue.value = value
+  emit('update:dateString', value)
+  const date = stringToDate(value)
+  emit('update:modelValue', date)
+}
 </script>
 
 <template>
@@ -31,10 +57,10 @@ const input = ref<HTMLInputElement>()
     <input
       ref="input"
       v-bind="{ ...$attrs, class: null, style: null }"
-      type="date"
-      :value="modelValue"
+      :type="dateType"
+      :value="inputValue"
       class="htw-text-inherit htw-bg-transparent htw-w-full htw-outline-none htw-px-2 htw-py-1 -htw-my-1 htw-border htw-border-solid htw-border-black/25 dark:htw-border-white/25 focus:htw-border-primary-500 dark:focus:htw-border-primary-500 htw-rounded-sm"
-      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      @input="onInputUpdate"
     >
 
     <template #actions>

--- a/packages/histoire-controls/src/components/date/HstDate.vue
+++ b/packages/histoire-controls/src/components/date/HstDate.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+export default {
+  name: 'HstDate',
+}
+</script>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import HstWrapper from '../HstWrapper.vue'
+
+defineProps<{
+  title?: string
+  modelValue?: string | null
+}>()
+
+const emit = defineEmits({
+  'update:modelValue': (newValue: string) => true,
+})
+
+const input = ref<HTMLInputElement>()
+</script>
+
+<template>
+  <HstWrapper
+    :title="title"
+    class="histoire-text htw-cursor-text htw-items-center"
+    :class="$attrs.class"
+    :style="$attrs.style"
+    @click="input.focus()"
+  >
+    <input
+      ref="input"
+      v-bind="{ ...$attrs, class: null, style: null }"
+      type="date"
+      :value="modelValue"
+      class="htw-text-inherit htw-bg-transparent htw-w-full htw-outline-none htw-px-2 htw-py-1 -htw-my-1 htw-border htw-border-solid htw-border-black/25 dark:htw-border-white/25 focus:htw-border-primary-500 dark:focus:htw-border-primary-500 htw-rounded-sm"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    >
+
+    <template #actions>
+      <slot name="actions" />
+    </template>
+  </HstWrapper>
+</template>

--- a/packages/histoire-controls/src/index.ts
+++ b/packages/histoire-controls/src/index.ts
@@ -3,6 +3,7 @@ import HstButtonGroupVue from './components/button/HstButtonGroup.vue'
 import HstCheckboxVue from './components/checkbox/HstCheckbox.vue'
 import HstCheckboxListVue from './components/checkbox/HstCheckboxList.vue'
 import HstColorSelectVue from './components/colorselect/HstColorSelect.vue'
+import HstDateVue from './components/date/HstDate.vue'
 import HstColorShadesVue from './components/design-tokens/HstColorShades.vue'
 import HstTokenGridVue from './components/design-tokens/HstTokenGrid.vue'
 import HstTokenListVue from './components/design-tokens/HstTokenList.vue'
@@ -19,6 +20,7 @@ export const HstButton = HstButtonVue
 export const HstButtonGroup = HstButtonGroupVue
 export const HstCheckbox = HstCheckboxVue
 export const HstCheckboxList = HstCheckboxListVue
+export const HstDate = HstDateVue
 export const HstText = HstTextVue
 export const HstNumber = HstNumberVue
 export const HstSlider = HstSliderVue
@@ -38,6 +40,7 @@ export const components = {
   HstCheckbox,
   HstCheckboxList,
   HstText,
+  HstDate,
   HstNumber,
   HstSlider,
   HstTextarea,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#### Use case

In some cases, we need to pass Date object instance to component props. But we lack support for native _Histoire_ controllers for selecting dates.

I personally need this on my company's Histoire environment, and I had to tweak a `HstText` component to validate only date texts, convert it to date instance, and make sure it doesn't break anything.

Since `HstText` enforces the input `type` to be `text` (the `v-bind` is overridden), we can't use it with `type="date"`. And I thought we probably shouldn't, as it would make the component too versatile. It would not handle edge cases, validation and so on.

#### Solution

So I implemented this new controller component `HstDate` to select a Date. It's a native input **date** / **datetime** picker, which emits the Date instance object, and also the textual value hold by the `<input>` element.

My first thought was to support both `Date` and `string` models, both synced together. But it brings a whole lot of issues, especially if we use both models at the same time (which one takes precedence?). So I decided to focus on the `Date` model instead, which is I think the main use case we would use this controller component.

### Additional context

Since it's my first contribution, I'm not sure if this component respects the repo best practices and code style.
I also need feedback over the component naming and its story organization.

Should I add some examples in the `examples` package?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
