### PR TITLE
fix: readability of markdown files

### DIFF
--- a/examples/vue3/src/MarkdownFile.story.md
+++ b/examples/vue3/src/MarkdownFile.story.md
@@ -1,3 +1,142 @@
 # Markdown file
 
 This is a standalone `MarkdownFile.story.md` file, rendering as a docs-only story.
+
+---
+__Advertisement :)__
+
+- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality and fast image
+  resize in browser.
+- __[babelfish](https://github.com/nodeca/babelfish/)__ - developer friendly
+  i18n with plurals support and easy syntax.
+
+You will like those projects!
+
+---
+
+# h1 Heading 8-)
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+
+## Horizontal Rules
+
+___
+
+---
+
+***
+
+## Typographic replacements
+
+Enable typographer option to see result.
+
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+
+test.. test... test..... test?..... test!....
+
+!!!!!! ???? ,,  -- ---
+
+"Smartypants, double quotes" and 'single quotes'
+
+## Emphasis
+
+**This is bold text**
+
+__This is bold text__
+
+*This is italic text*
+
+_This is italic text_
+
+~~Strikethrough~~
+
+## Blockquotes
+
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+## Lists
+
+Unordered
+
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ Very easy!
+
+Ordered
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+1. You can use sequential numbers...
+1. ...or keep all the numbers as `1.`
+
+Start numbering with offset:
+
+57. foo
+1. bar
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+
+``` js
+const foo = function (bar) {
+  return bar++
+}
+
+console.warn(foo(5))
+```
+
+## Tables
+
+| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+Right aligned columns
+
+| Option | Description |
+| ------:| -----------:|
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ "title text!")
+
+Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")

--- a/examples/vue3/src/MarkdownFile.story.md
+++ b/examples/vue3/src/MarkdownFile.story.md
@@ -3,55 +3,33 @@
 This is a standalone `MarkdownFile.story.md` file, rendering as a docs-only story.
 
 ---
-__Advertisement :)__
 
-- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality and fast image
-  resize in browser.
-- __[babelfish](https://github.com/nodeca/babelfish/)__ - developer friendly
-  i18n with plurals support and easy syntax.
+## Headings
 
-You will like those projects!
-
----
-
-# h1 Heading 8-)
+# h1 Heading
 ## h2 Heading
 ### h3 Heading
 #### h4 Heading
 ##### h5 Heading
 ###### h6 Heading
 
-## Horizontal Rules
-
-___
-
 ---
 
-***
+## Links
 
-## Typographic replacements
+[link](https://histoire.dev "title text!")
 
-Enable typographer option to see result.
-
-(c) (C) (r) (R) (tm) (TM) (p) (P) +-
-
-test.. test... test..... test?..... test!....
-
-!!!!!! ???? ,,  -- ---
-
-"Smartypants, double quotes" and 'single quotes'
+---
 
 ## Emphasis
 
 **This is bold text**
 
-__This is bold text__
-
 *This is italic text*
 
-_This is italic text_
-
 ~~Strikethrough~~
+
+---
 
 ## Blockquotes
 
@@ -59,51 +37,38 @@ _This is italic text_
 >> ...by using additional greater-than signs right next to each other...
 > > > ...or with spaces between arrows.
 
+---
+
 ## Lists
 
-Unordered
+### Unordered
 
-+ Create a list by starting a line with `+`, `-`, or `*`
-+ Sub-lists are made by indenting 2 spaces:
+- Create a list by starting a line with `+`, `-`, or `*`
+- Sub-lists are made by indenting 2 spaces:
   - Marker character change forces new list start:
-    * Ac tristique libero volutpat at
-    + Facilisis in pretium nisl aliquet
+    - Ac tristique libero volutpat at
+    - Facilisis in pretium nisl aliquet
     - Nulla volutpat aliquam velit
-+ Very easy!
+- Very easy!
 
-Ordered
+### Ordered
 
 1. Lorem ipsum dolor sit amet
 2. Consectetur adipiscing elit
 3. Integer molestie lorem at massa
 
-1. You can use sequential numbers...
-1. ...or keep all the numbers as `1.`
-
-Start numbering with offset:
-
-57. foo
-1. bar
+---
 
 ## Code
 
 Inline `code`
 
-Indented code
-
-    // Some comments
-    line 1 of code
-    line 2 of code
-    line 3 of code
-
 Block code "fences"
-
 ```
 Sample text here...
 ```
 
 Syntax highlighting
-
 ``` js
 const foo = function (bar) {
   return bar++
@@ -112,31 +77,20 @@ const foo = function (bar) {
 console.warn(foo(5))
 ```
 
+---
+
 ## Tables
 
-| Option | Description |
-| ------ | ----------- |
+| Option | Description                                                               |
+| ------ | ------------------------------------------------------------------------- |
 | data   | path to data files to supply the data that will be passed into templates. |
-| engine | engine to be used for processing templates. Handlebars is the default. |
-| ext    | extension to be used for dest files. |
+| engine | engine to be used for processing templates. Handlebars is the default.    |
+| ext    | extension to be used for dest files.                                      |
 
-Right aligned columns
-
-| Option | Description |
-| ------:| -----------:|
-| data   | path to data files to supply the data that will be passed into templates. |
-| engine | engine to be used for processing templates. Handlebars is the default. |
-| ext    | extension to be used for dest files. |
-
-## Links
-
-[link text](http://dev.nodeca.com)
-
-[link with title](http://nodeca.github.io/pica/demo/ "title text!")
-
-Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+---
 
 ## Images
 
-![Minion](https://octodex.github.com/images/minion.png)
 ![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+---

--- a/packages/histoire-app/src/app/style/main.pcss
+++ b/packages/histoire-app/src/app/style/main.pcss
@@ -10,8 +10,6 @@
 ::after {
   box-sizing: border-box;
   border-width: 0;
-  border-style: solid;
-  border-color: #e5e7eb;
 }
 
 a,

--- a/packages/histoire-app/tailwind.config.cjs
+++ b/packages/histoire-app/tailwind.config.cjs
@@ -71,67 +71,34 @@ delete module.exports.theme.extend.colors.gray
 module.exports.theme.colors = colors
 
 module.exports.plugins.push(require('@tailwindcss/typography'))
-// prose-a:htw-text-primary-500 prose-headings:htw-mb-2 prose-headings:htw-mt-4 first:prose-headings:htw-mt-0 prose-blockquote:htw-ml-0
+
 module.exports.theme.extend.typography = theme => ({
   DEFAULT: {
     css: {
-      'a': {
-        'color': theme('colors.primary-500'),
-        'textDecoration': 'none',
-
-        '&:hover': {
-          textDecoration: 'underline',
-        },
+      // Custom style
+      'table': {
+        borderCollapse: 'collapse',
       },
-
-      'h1, h2, h3, h4, th': {
-        'marginBottom': '0.75rem',
-
-        '&:not(:first-child)': {
-          marginTop: '1.25rem',
-        },
+      'thead, tr, blockquote': {
+        borderStyle: 'solid',
       },
-
-      '--tw-prose-invert-quote-borders': theme('colors.gray-800'),
-      '--tw-prose-invert-hr': theme('colors.gray-800'),
-
       'blockquote': {
-        'marginLeft': 0,
-        'marginRight': 0,
-        'backgroundColor': theme('colors.gray-100'),
-        'padding': '.25rem .375rem',
-
-        '& p:first-child': {
-          marginTop: 0,
-        },
-
-        '& p:last-child': {
-          marginBottom: 0,
-        },
-
-        '.dark &': {
-          backgroundColor: theme('colors.gray-750'),
-        },
+        marginInlineStart: '0.375rem',
+        marginInlineEnd: '0.375rem',
       },
 
+      // Theme variables
+      // Light
+      '--tw-prose-links': theme('colors.primary-500'),
+      '--tw-prose-pre-bg': theme('colors.gray-800'),
+      // Dark
+      '--tw-prose-invert-links': theme('colors.primary-500'),
+      '--tw-prose-invert-quote-borders': theme('colors.gray-500'),
+      '--tw-prose-invert-hr': theme('colors.gray-500'),
+      '--tw-prose-invert-th-borders': theme('colors.gray-500'),
+      '--tw-prose-invert-td-borders': theme('colors.gray-600'),
       '--tw-prose-invert-bullets': theme('colors.gray-500'),
-
-      'li': {
-        marginTop: '0.1rem',
-        marginBottom: '0.1rem',
-      },
-
-      'code': {
-        'backgroundColor': theme('colors.gray-500 / 20%'),
-        'fontWeight': 'normal',
-        'padding': '0.05rem 0.5rem',
-        'borderRadius': '0.25rem',
-        'fontSize': '0.8rem',
-
-        '&::before, &::after': {
-          display: 'none',
-        },
-      },
+      '--tw-prose-invert-pre-bg': theme('colors.gray-800'),
     },
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR improves the readability of Markdown documentation by refining the visual consistency across different themes.

### Additional context

- **Fixed blockquote styling:** The blockquote no longer remains in light mode when the dark theme is active.
- **Table borders:** Added previously missing borders to tables.
- **Simplified styling:** The overall styling has been simplified for now.

I'm open to feedback and further improvements. Let me know if you have any suggestions, and I'll be happy to implement them.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
