### PR TITLE
fix(node): suppress JSDOM CSS parse errors during story collection

### DIFF
--- a/packages/histoire/src/node/__tests__/dom-env.spec.ts
+++ b/packages/histoire/src/node/__tests__/dom-env.spec.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDomEnv } from '../dom/env.js'
+
+describe('createDomEnv', () => {
+  let env: ReturnType<typeof createDomEnv>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  afterEach(() => {
+    env?.destroy()
+    errorSpy?.mockRestore()
+  })
+
+  describe('when a stylesheet contains unparseable directives (e.g. Tailwind @apply)', () => {
+    it('does not log a css-parsing jsdomError', () => {
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      env = createDomEnv()
+      const style = env.window.document.createElement('style')
+      style.textContent = '@tailwind base; @apply text-red-500 { }; ::not-a-real-pseudo {}'
+
+      env.window.document.head.appendChild(style)
+
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a script throws an unhandled exception', () => {
+    it('forwards the error to console.error', () => {
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      env = createDomEnv()
+      const script = env.window.document.createElement('script')
+      script.textContent = 'throw new Error("boom from story script")'
+
+      env.window.document.head.appendChild(script)
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('boom from story script'))
+    })
+  })
+})

--- a/packages/histoire/src/node/dom/env.ts
+++ b/packages/histoire/src/node/dom/env.ts
@@ -4,6 +4,28 @@ import {
 } from 'jsdom'
 import { populateGlobal } from './util.js'
 
+// jsdom error types — not exported by jsdom.
+const JSDOM_ERROR_CSS_PARSING = 'css-parsing'
+const JSDOM_ERROR_UNHANDLED_EXCEPTION = 'unhandled-exception'
+
+// Tailwind directives (@tailwind, @apply, @theme) crash JSDOM's CSS parser
+// and dump the whole stylesheet to stderr. Drop css-parsing errors; mirror
+// jsdom's default forwardTo for the rest.
+function createVirtualConsole(): VirtualConsole | undefined {
+  if (!console || !globalThis.console) return undefined
+  const virtualConsole = new VirtualConsole().forwardTo(globalThis.console, { jsdomErrors: 'none' })
+  virtualConsole.on('jsdomError', (err: Error & { type?: string, cause?: { stack?: string } }) => {
+    if (err.type === JSDOM_ERROR_CSS_PARSING) return
+    if (err.type === JSDOM_ERROR_UNHANDLED_EXCEPTION) {
+      globalThis.console.error(err.cause?.stack ?? err.message)
+    }
+    else {
+      globalThis.console.error(err.message)
+    }
+  })
+  return virtualConsole
+}
+
 export function createDomEnv() {
   const dom = new JSDOM(
     '<!DOCTYPE html>',
@@ -11,7 +33,7 @@ export function createDomEnv() {
       pretendToBeVisual: true,
       runScripts: 'dangerously',
       url: 'http://localhost:3000',
-      virtualConsole: console && globalThis.console ? new VirtualConsole().forwardTo(globalThis.console) : undefined,
+      virtualConsole: createVirtualConsole(),
       includeNodeLocations: false,
       contentType: 'text/html',
     },


### PR DESCRIPTION
Closes #501. Plausibly closes #557 and #466 (same root cause).

JSDOM's CSS parser doesn't understand Tailwind directives (`@tailwind`, `@apply`, `@theme`), CSS container queries, modern selectors, etc. When story collection mounts user stylesheets via setup files, JSDOM emits a `jsdomError` of type `'css-parsing'` whose payload includes the **entire stylesheet** — extremely noisy and not actionable, since stories don't rely on rendered styles during collection.

`VirtualConsole.forwardTo()` defaults to forwarding every `jsdomError` to `console.error`, hence the spam.

This change disables blanket forwarding (`{ jsdomErrors: 'none' }`) and re-attaches a manual listener that drops `css-parsing` and forwards everything else, mirroring jsdom's default behavior for `unhandled-exception` and other types.

## Test plan

- [x] New unit tests in `packages/histoire/src/node/__tests__/dom-env.spec.ts`:
  - Stylesheet with Tailwind-style unparseable directives → 0 `console.error` calls
  - `<script>` that throws → `console.error` IS called with the stack
- [x] `pnpm test` passes (9/9)
- [x] Build and lint pass