### PR TITLE
feat: sandbox-only color scheme switch

### DIFF
--- a/examples/vue3/cypress/e2e/toolbar-background.cy.js
+++ b/examples/vue3/cypress/e2e/toolbar-background.cy.js
@@ -24,10 +24,10 @@ describe('background color', () => {
     'rgb(0, 81, 66)',
   ]
 
-  it('should provide background and contrast color (no iframe)', () => {
+  it('applies the picked preset to inline-rendered stories', () => {
     cy.visit('/story/src-components-complexparameter-story-vue?variantId=_default')
     cy.get('[data-test-id="toolbar-background"]').click()
-    cy.get('[data-test-id="background-popper"]').should('be.visible').find('button').should('have.length', 6).each(($el, index) => {
+    cy.get('[data-test-id="background-popper"]').should('be.visible').find('> button').should('have.length', 6).each(($el, index) => {
       cy.wrap($el).click()
       cy.get('[data-test-id="responsive-preview-bg"]').should('have.css', 'background-color', backgroundColorShouldBe[index])
       cy.get('[data-test-id="story-variant-single-view"] .native-story').should('have.css', 'color', contrastColorShouldBe[index])
@@ -35,20 +35,20 @@ describe('background color', () => {
     })
   })
 
-  it('should provide background and contrast color (with iframe)', () => {
+  it('applies the picked preset to single-iframe stories', () => {
     cy.visit('story/src-components-contrastcolor-story-vue?variantId=_default')
     cy.get('[data-test-id="toolbar-background"]').click()
-    cy.get('[data-test-id="background-popper"]').should('be.visible').find('button').should('have.length', 6).each(($el, index) => {
+    cy.get('[data-test-id="background-popper"]').should('be.visible').find('> button').should('have.length', 6).each(($el, index) => {
       cy.wrap($el).click()
       getIframeBody().find('.contrast-color').should('have.css', 'color', contrastColorShouldBe[index])
       cy.get('[data-test-id="toolbar-background"]').click()
     })
   })
 
-  it('should provide background and contrast color (grid)', () => {
+  it('applies the picked preset to grid-rendered stories', () => {
     cy.visit('/story/src-components-substory-story-vue?variantId=src-components-substory-story-vue-0')
     cy.get('[data-test-id="toolbar-background"]').click()
-    cy.get('[data-test-id="background-popper"]').should('be.visible').find('button').should('have.length', 6).each(($el, index) => {
+    cy.get('[data-test-id="background-popper"]').should('be.visible').find('> button').should('have.length', 6).each(($el, index) => {
       cy.wrap($el).click()
       cy.get('[data-test-id="responsive-preview-bg"]').should('have.css', 'background-color', backgroundColorShouldBe[index])
       cy.get('.histoire-generic-render-story .text').should('have.css', 'color', contrastColorShouldBe[index])

--- a/packages/histoire-app/src/app/components/toolbar/ToolbarBackground.vue
+++ b/packages/histoire-app/src/app/components/toolbar/ToolbarBackground.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { SandboxColorScheme } from '../../types'
 import { Icon } from '@iconify/vue'
 import { computed } from 'vue'
 import { usePreviewSettingsStore } from '../../stores/preview-settings'
@@ -9,6 +10,12 @@ import BaseCheckbox from '../base/BaseCheckbox.vue'
 const settings = usePreviewSettingsStore().currentSettings
 
 const contrastColor = computed(() => getContrastColor(settings))
+
+const colorSchemeOptions: { value: SandboxColorScheme, label: string, icon: string }[] = [
+  { value: 'auto', label: 'System', icon: 'carbon:screen' },
+  { value: 'light', label: 'Light', icon: 'carbon:sun' },
+  { value: 'dark', label: 'Dark', icon: 'carbon:moon' },
+]
 </script>
 
 <template>
@@ -39,6 +46,26 @@ const contrastColor = computed(() => getContrastColor(settings))
         class="htw-flex htw-flex-col htw-items-stretch"
         data-test-id="background-popper"
       >
+        <div
+          class="htw-flex htw-items-stretch htw-px-2 htw-pt-2 htw-gap-1"
+          data-test-id="sandbox-color-scheme"
+        >
+          <button
+            v-for="option in colorSchemeOptions"
+            :key="option.value"
+            class="htw-flex-1 htw-px-3 htw-py-1.5 htw-rounded htw-flex htw-items-center htw-justify-center htw-gap-1.5 htw-cursor-pointer htw-text-sm"
+            :class="[
+              settings.colorScheme === option.value
+                ? 'htw-bg-primary-500 hover:htw-bg-primary-600 htw-text-white dark:htw-text-black'
+                : 'htw-bg-transparent hover:htw-bg-primary-100 dark:hover:htw-bg-primary-700',
+            ]"
+            @click="settings.colorScheme = option.value"
+          >
+            <Icon :icon="option.icon" class="htw-w-4 htw-h-4" />
+            <span>{{ option.label }}</span>
+          </button>
+        </div>
+
         <BaseCheckbox v-model="settings.checkerboard">
           Checkerboard
         </BaseCheckbox>

--- a/packages/histoire-app/src/app/sandbox.ts
+++ b/packages/histoire-app/src/app/sandbox.ts
@@ -1,5 +1,6 @@
 import type { StoryFile } from './types'
 import { applyState } from '@histoire/shared'
+import { usePreferredDark } from '@vueuse/core'
 import { createPinia } from 'pinia'
 import { files } from 'virtual:$histoire-stories'
 import { computed, createApp, h, onMounted, ref, watch } from 'vue'
@@ -11,7 +12,7 @@ import { histoireConfig } from './util/config.js'
 import { PREVIEW_SETTINGS_SYNC, SANDBOX_READY, STATE_SYNC } from './util/const.js'
 import { isDark } from './util/dark.js'
 import { mapFile } from './util/mapping'
-import { applyPreviewSettings } from './util/preview-settings.js'
+import { applyPreviewSettings, receivedSettings } from './util/preview-settings.js'
 import { toRawDeep } from './util/state.js'
 
 const query = parseQuery(window.location.search)
@@ -83,7 +84,18 @@ const app = createApp({
 app.use(createPinia())
 app.mount('#app')
 
-watch(isDark, (value) => {
+// Default branch covers the boot window before the first PREVIEW_SETTINGS_SYNC arrives.
+const prefersDark = usePreferredDark()
+const effectiveDark = computed(() => {
+  switch (receivedSettings.colorScheme) {
+    case 'light': return false
+    case 'dark': return true
+    case 'auto': return prefersDark.value
+    default: return isDark.value
+  }
+})
+
+watch(effectiveDark, (value) => {
   if (value) {
     document.documentElement.classList.add(histoireConfig.sandboxDarkClass) // @TODO remove
     document.documentElement.classList.add(histoireConfig.theme.darkClass)

--- a/packages/histoire-app/src/app/stores/preview-settings.ts
+++ b/packages/histoire-app/src/app/stores/preview-settings.ts
@@ -10,6 +10,7 @@ export const usePreviewSettingsStore = defineStore('preview-settings', () => {
     backgroundColor: 'transparent',
     checkerboard: false,
     textDirection: 'ltr',
+    colorScheme: 'auto',
   })
 
   return {

--- a/packages/histoire-app/src/app/types.ts
+++ b/packages/histoire-app/src/app/types.ts
@@ -45,6 +45,8 @@ export type SearchResult = SearchResultBase & ({
   onActivate: () => unknown
 })
 
+export type SandboxColorScheme = 'auto' | 'light' | 'dark'
+
 export interface PreviewSettings {
   responsiveWidth: number
   responsiveHeight: number
@@ -52,6 +54,7 @@ export interface PreviewSettings {
   backgroundColor: string
   checkerboard: boolean
   textDirection: 'ltr' | 'rtl'
+  colorScheme: SandboxColorScheme
 }
 
 declare module 'vue' {


### PR DESCRIPTION
**Why I started this**

When I work on a component I usually want to test it in light, dark, and OS-preferred mode. The only way today is to flip the whole Histoire chrome — which is annoying because I lose my chrome preference every time.

So this PR decouples the sandbox color scheme from the chrome. Same UX I filed in [#398](https://github.com/histoire-dev/histoire/discussions/398) back in 2022 (with a PoC video).

**What changed**

- 3 buttons at the top of the Background popper: System / Light / Dark
- new `colorScheme: 'auto' | 'light' | 'dark'` on `PreviewSettings`, default `'auto'`
- sandbox uses its own setting via `usePreferredDark()`; the chrome toggle only flips chrome

**Heads-up**: sandbox used to follow chrome. Now it defaults to OS preference. If your chrome and OS match (most cases), nothing visibly changes.