### PR TITLE
fix(app): forward keyboard shortcuts from sandbox iframes

### DIFF
--- a/packages/histoire-app/src/app/components/story/StoryVariantSinglePreviewRemote.vue
+++ b/packages/histoire-app/src/app/components/story/StoryVariantSinglePreviewRemote.vue
@@ -3,10 +3,11 @@ import type { HstEvent } from '../../stores/events'
 import type { Story, Variant } from '../../types'
 import { applyState } from '@histoire/shared'
 import { useEventListener } from '@vueuse/core'
-import { computed, ref, toRaw, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, toRaw, watch } from 'vue'
 import { useEventsStore } from '../../stores/events'
 import { usePreviewSettingsStore } from '../../stores/preview-settings'
 import { EVENT_SEND, PREVIEW_SETTINGS_SYNC, SANDBOX_READY, STATE_SYNC } from '../../util/const'
+import { trackWindow } from '../../util/keyboard'
 import { getSandboxUrl } from '../../util/sandbox'
 import { toRawDeep } from '../../util/state'
 import StoryResponsivePreview from './StoryResponsivePreview.vue'
@@ -84,11 +85,21 @@ const sandboxUrl = computed(() => {
 
 const isIframeLoaded = ref(false)
 
+let stopTrackKeyboard: (() => void) | undefined
+let unmounted = false
+
 watch(sandboxUrl, () => {
   isIframeLoaded.value = false
   Object.assign(props.variant, {
     previewReady: false,
   })
+  stopTrackKeyboard?.()
+  stopTrackKeyboard = undefined
+})
+
+onBeforeUnmount(() => {
+  unmounted = true
+  stopTrackKeyboard?.()
 })
 
 // Settings
@@ -112,9 +123,14 @@ watch(() => settings, () => {
 // Iframe load
 
 function onIframeLoad() {
+  if (unmounted) return
   isIframeLoaded.value = true
   syncState()
   syncSettings()
+  stopTrackKeyboard?.()
+  if (iframe.value?.contentWindow) {
+    stopTrackKeyboard = trackWindow(iframe.value.contentWindow)
+  }
 }
 </script>
 

--- a/packages/histoire-app/src/app/util/keyboard.ts
+++ b/packages/histoire-app/src/app/util/keyboard.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
-import { isRef } from 'vue'
+import { isRef, ref } from 'vue'
 import { isMac } from './env.js'
 
 export type KeyboardShortcut = string[]
@@ -9,14 +9,6 @@ export type KeyboardHandler = (event: KeyboardEvent) => unknown
 
 export interface KeyboardShortcutOptions {
   event?: 'keyup' | 'keydown' | 'keypress'
-}
-
-export function onKeyboardShortcut(shortcut: KeyboardShortcut | Ref<KeyboardShortcut>, handler: KeyboardHandler, options: KeyboardShortcutOptions = {}) {
-  useEventListener(options.event ?? 'keydown', (event) => {
-    if (isMatchingShortcut(isRef(shortcut) ? shortcut.value : shortcut)) {
-      handler(event)
-    }
-  })
 }
 
 const modifiers: { [i: string]: { key: string, pressed: boolean } } = {
@@ -28,37 +20,67 @@ const modifiers: { [i: string]: { key: string, pressed: boolean } } = {
 
 const pressedKeys = new Set<string>()
 
-window.addEventListener('keydown', (event) => {
-  for (const i in modifiers) {
-    const mod = modifiers[i]
-    if (mod.key === event.key) {
-      mod.pressed = true
-      return
-    }
-  }
-  pressedKeys.add(event.key.toLocaleLowerCase())
-})
+const trackedWindows = ref<Window[]>([])
 
-window.addEventListener('keyup', (event) => {
-  requestAnimationFrame(() => {
-    pressedKeys.clear()
+function bindTracking(target: Window) {
+  const onKeydown = (event: KeyboardEvent) => {
     for (const i in modifiers) {
       const mod = modifiers[i]
       if (mod.key === event.key) {
-        mod.pressed = false
-        break
+        mod.pressed = true
+        return
       }
     }
-  })
-})
-
-window.addEventListener('blur', () => {
-  pressedKeys.clear()
-  for (const i in modifiers) {
-    const mod = modifiers[i]
-    mod.pressed = false
+    pressedKeys.add(event.key.toLocaleLowerCase())
   }
-})
+  const onKeyup = (event: KeyboardEvent) => {
+    requestAnimationFrame(() => {
+      pressedKeys.clear()
+      for (const i in modifiers) {
+        const mod = modifiers[i]
+        if (mod.key === event.key) {
+          mod.pressed = false
+          break
+        }
+      }
+    })
+  }
+  const onBlur = () => {
+    pressedKeys.clear()
+    for (const i in modifiers) {
+      modifiers[i].pressed = false
+    }
+  }
+  target.addEventListener('keydown', onKeydown)
+  target.addEventListener('keyup', onKeyup)
+  target.addEventListener('blur', onBlur)
+  return () => {
+    target.removeEventListener('keydown', onKeydown)
+    target.removeEventListener('keyup', onKeyup)
+    target.removeEventListener('blur', onBlur)
+  }
+}
+
+// Forward shortcuts from sandbox iframes. Closes #350.
+export function trackWindow(target: Window): () => void {
+  if (trackedWindows.value.includes(target)) return () => {}
+  const cleanup = bindTracking(target)
+  trackedWindows.value = [...trackedWindows.value, target]
+  return () => {
+    cleanup()
+    trackedWindows.value = trackedWindows.value.filter(w => w !== target)
+  }
+}
+
+trackWindow(window)
+
+export function onKeyboardShortcut(shortcut: KeyboardShortcut | Ref<KeyboardShortcut>, handler: KeyboardHandler, options: KeyboardShortcutOptions = {}) {
+  useEventListener(trackedWindows, options.event ?? 'keydown', (event) => {
+    if (isMatchingShortcut(isRef(shortcut) ? shortcut.value : shortcut)) {
+      handler(event)
+    }
+  })
+}
 
 function isMatchingShortcut(shortcut: KeyboardShortcut): boolean {
   for (const combination of shortcut) {

--- a/packages/histoire-app/src/app/util/keyboard.ts
+++ b/packages/histoire-app/src/app/util/keyboard.ts
@@ -75,7 +75,13 @@ export function trackWindow(target: Window): () => void {
 trackWindow(window)
 
 export function onKeyboardShortcut(shortcut: KeyboardShortcut | Ref<KeyboardShortcut>, handler: KeyboardHandler, options: KeyboardShortcutOptions = {}) {
-  useEventListener(trackedWindows, options.event ?? 'keydown', (event) => {
+  useEventListener(trackedWindows, options.event ?? 'keydown', (event: KeyboardEvent) => {
+    // Sync modifier state from the event so a blur-clear (e.g. focusing an
+    // iframe while holding a modifier) doesn't drop the shortcut.
+    modifiers.ctrl.pressed = event.ctrlKey
+    modifiers.alt.pressed = event.altKey
+    modifiers.shift.pressed = event.shiftKey
+    modifiers.meta.pressed = event.metaKey
     if (isMatchingShortcut(isRef(shortcut) ? shortcut.value : shortcut)) {
       handler(event)
     }


### PR DESCRIPTION
**Why I started this**

Every time i focus a story preview the global shortcuts (search, dark-mode toggle, etc.) silently die. On Safari `meta+shift+d` even gets stolen by "Add to Reading List". I diagnosed it in [#350](https://github.com/histoire-dev/histoire/issues/350) back in 2023 — the parent's key listeners only see events fired on the parent window, so anything fired while the iframe has focus is lost.

**What changed**

- `keyboard.ts` exports a `trackWindow(target)` so additional windows can opt into the same shortcut tracking
- iframe wrapper calls it on `contentWindow` after load, cleans up on URL change / unmount
- `event.preventDefault()` now runs inside the iframe, blocking Safari's reading-list grab

Closes #350.