### PR TITLE
chore: drop stale flexsearch optimizeDeps entry

### DIFF
--- a/packages/histoire/src/node/vite.ts
+++ b/packages/histoire/src/node/vite.ts
@@ -124,7 +124,6 @@ export async function getViteConfigWithPlugins(isServer: boolean, ctx: Context):
             `${APP_PATH}/bundle-sandbox.js`,
           ],
           include: optimizeDeps([
-            'flexsearch',
             'shiki',
             // Shiki dependencies
             'vscode-oniguruma',


### PR DESCRIPTION
Search migrated to `fuse.js` in #770 (Vite 6 upgrade) but this include reference was missed. No runtime effect today; just dead code.

Closed #646 , #532