### PR TITLE
feat(config): add defaultPreviewSettings to seed initial preview-pane state

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -190,6 +190,27 @@ export default defineConfig({
 })
 ```
 
+## `defaultPreviewSettings`
+
+`Object`
+
+Initial values for the persisted preview-settings store. Lets you seed the responsive size picker (which otherwise defaults to 720px) and other preview-pane UI state. Each field is optional; omitted fields fall back to the built-in default. Set `responsiveWidth: null` to default the picker to "Auto" so previews render at their natural width.
+
+Only seeds the store on first visit (or when local storage hasn't yet been written). Once the user changes a setting via the toolbar, their choice is persisted and takes precedence.
+
+```ts
+export default defineConfig({
+  defaultPreviewSettings: {
+    responsiveWidth: null, // null → "Auto"
+    responsiveHeight: null,
+    rotate: false,
+    backgroundColor: 'transparent',
+    checkerboard: false,
+    textDirection: 'ltr',
+  },
+})
+```
+
 ## `responsivePresets`
 
 `Array`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -220,8 +220,8 @@ Predefined responsive sizes for story playgrounds.
 Each object in the array is a preset with the following properties:
 
 - `label: string`: Label for the preset.
-- `width: number`: Width of the preset (pixels).
-- `height: number`: Height of the preset (pixels).
+- `width: number | null`: Width of the preset (pixels). Pass `null` to leave the width unconstrained ("Auto").
+- `height: number | null`: Height of the preset (pixels). Pass `null` to leave the height unconstrained ("Auto").
 
 Default values are shown in the example below:
 

--- a/packages/histoire-app/src/app/stores/preview-settings.ts
+++ b/packages/histoire-app/src/app/stores/preview-settings.ts
@@ -1,15 +1,25 @@
 import type { PreviewSettings } from '../types'
 import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
+import { histoireConfig } from '../util/config'
+
+const builtinDefaults: PreviewSettings = {
+  responsiveWidth: 720,
+  responsiveHeight: null,
+  rotate: false,
+  backgroundColor: 'transparent',
+  checkerboard: false,
+  textDirection: 'ltr',
+}
 
 export const usePreviewSettingsStore = defineStore('preview-settings', () => {
+  // Merge built-in defaults with the optional user-supplied
+  // `defaultPreviewSettings` from histoire.config.js. Only seeds the
+  // localStorage-backed store on first visit; later toolbar changes
+  // persist normally and win on subsequent loads.
   const currentSettings = useStorage<PreviewSettings>('_histoire-sandbox-settings-v3', {
-    responsiveWidth: 720,
-    responsiveHeight: null,
-    rotate: false,
-    backgroundColor: 'transparent',
-    checkerboard: false,
-    textDirection: 'ltr',
+    ...builtinDefaults,
+    ...histoireConfig.defaultPreviewSettings,
   })
 
   return {

--- a/packages/histoire-app/src/app/types.ts
+++ b/packages/histoire-app/src/app/types.ts
@@ -1,6 +1,7 @@
 import type { RouteLocationRaw } from 'vue-router'
 
 export type {
+  PreviewSettings,
   Story,
   StoryFile,
   StoryLayout,
@@ -44,15 +45,6 @@ export type SearchResult = SearchResultBase & ({
 } | {
   onActivate: () => unknown
 })
-
-export interface PreviewSettings {
-  responsiveWidth: number
-  responsiveHeight: number
-  rotate: boolean
-  backgroundColor: string
-  checkerboard: boolean
-  textDirection: 'ltr' | 'rtl'
-}
 
 declare module 'vue' {
   interface ComponentCustomProperties {

--- a/packages/histoire-shared/src/types/config.ts
+++ b/packages/histoire-shared/src/types/config.ts
@@ -28,6 +28,17 @@ export interface BackgroundPreset {
   contrastColor?: string
 }
 
+export interface PreviewSettings {
+  /** Width of the responsive preview. `null` renders as "Auto" (no constraint). */
+  responsiveWidth: number | null
+  /** Height of the responsive preview. `null` renders as "Auto" (no constraint). */
+  responsiveHeight: number | null
+  rotate: boolean
+  backgroundColor: string
+  checkerboard: boolean
+  textDirection: 'ltr' | 'rtl'
+}
+
 export interface TreeGroupConfig {
   title: string
   id?: string
@@ -181,6 +192,19 @@ export interface HistoireConfig {
    * @deprecated use `theme.darkClass` instead
    */
   sandboxDarkClass?: string
+  /**
+   * Initial values for the persisted preview-settings store. Lets users
+   * change the seed for the responsive size picker (which is otherwise
+   * hardcoded to 720px) or any other preview-pane UI setting. Each field
+   * is optional; omitted fields fall back to the built-in default. Set
+   * `responsiveWidth: null` to default the picker to "Auto" so previews
+   * render at their natural width.
+   *
+   * Only seeds the store on first visit (or when localStorage hasn't yet
+   * been written). Once the user changes a setting via the toolbar,
+   * their choice is persisted and takes precedence.
+   */
+  defaultPreviewSettings?: Partial<PreviewSettings>
   /**
    * Default props for stories.
    */

--- a/packages/histoire-shared/src/types/config.ts
+++ b/packages/histoire-shared/src/types/config.ts
@@ -18,8 +18,10 @@ export type GrayColorKeys = ColorKeys | '750' | '850' | '950'
 
 export interface ResponsivePreset {
   label: string
-  width: number
-  height?: number
+  /** Width in pixels. `null` renders as "Auto" (no constraint). */
+  width: number | null
+  /** Height in pixels. `null` renders as "Auto" (no constraint). */
+  height?: number | null
 }
 
 export interface BackgroundPreset {


### PR DESCRIPTION
## Summary

  Adds a new top-level config field `defaultPreviewSettings: Partial<PreviewSettings>` so users can seed the persisted
  preview-settings store from `histoire.config.js`. The primary motivation: change the responsive size picker's initial width away from its hardcoded 720px default so stories can render at their natural width on a first visit.

  ```js
  // histoire.config.js
  import { defineConfig } from 'histoire'

  export default defineConfig({
    defaultPreviewSettings: {
      responsiveWidth: null, // null → "Auto"
    },
  })
  ```

  Each field of `defaultPreviewSettings` is optional; omitted fields fall back to the built-in default. Only seeds the store on
  first visit — once the user changes a setting via the toolbar, their choice persists and wins on later loads.

  ## Why

  The responsive size picker currently always boots at 720px because `useStorage` is seeded with `{ responsiveWidth: 720, ... }` in `packages/histoire-app/src/app/stores/preview-settings.ts`. There is no way to change that seed from `defineConfig`. For projects where the typical primitive is best previewed at its natural width (forms, dialogs, list items) the 720px starting point reads like a bug — every story loads constrained until the user clicks the picker.

  The two pre-existing workarounds both have meaningful downsides:

  - `defaultStoryProps.responsiveDisabled: true` — removes the picker entirely, losing the ability to QA at mobile widths.
  - Custom `responsivePresets` with a "Full" preset — fails because `ResponsivePreset.width` is typed `number` (no `null`   allowed).

  This PR exposes the seed directly. The picker UI already handles `null` (`responsiveWidth.value ?? 'Auto'` at   `StoryResponsivePreview.vue:121`) so the implementation surface is small.

  ## What changed

  - `packages/histoire-shared/src/types/config.ts`
    - Added `PreviewSettings` interface (moved from `packages/histoire-app/src/app/types.ts`).
    - Added `defaultPreviewSettings?: Partial<PreviewSettings>` to `HistoireConfig`.
    - Widened `responsiveWidth` and `responsiveHeight` from `number` to `number | null`. The runtime already passed `null` for height; the `number`-only type was a latent mismatch. Picker UI's `?? 'Auto'` fallback only made sense if these were nullable.
  - `packages/histoire-app/src/app/types.ts`
    - `PreviewSettings` re-exported from `@histoire/shared`.
  - `packages/histoire-app/src/app/stores/preview-settings.ts`
    - `useStorage` seed merges built-in defaults with `histoireConfig.defaultPreviewSettings`.
  - `docs/reference/config.md`
    - New section after `defaultStoryProps` documenting the field.

  ## Test plan

  - [x] Existing stories still render at 720px when `defaultPreviewSettings` is omitted (built-in default preserved).
  - [x] Setting `defaultPreviewSettings.responsiveWidth: null` makes the picker boot at "Auto" on a fresh local-storage state.
  - [x] Once the user picks a different width via the toolbar, the choice persists across reloads (verified by inspecting   `_histoire-sandbox-settings-v3` in localStorage).

  ## Related

Closes #843 