### PR TITLE
deps(vue-plugin): bump launch-editor to patch shell-quote

### DIFF
--- a/packages/histoire-plugin-vue/package.json
+++ b/packages/histoire-plugin-vue/package.json
@@ -57,7 +57,7 @@
     "@histoire/vendors": "workspace:^",
     "change-case": "^5.4.4",
     "globby": "^14.0.2",
-    "launch-editor": "^2.9.1",
+    "launch-editor": "^2.14.0",
     "pathe": "^1.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,8 +768,8 @@ importers:
         specifier: ^14.0.2
         version: 14.1.0
       launch-editor:
-        specifier: ^2.9.1
-        version: 2.12.0
+        specifier: ^2.14.0
+        version: 2.14.1
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -5522,6 +5522,9 @@ packages:
   launch-editor@2.12.0:
     resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
 
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
+
   lazy-ass@1.6.0:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
     engines: {node: '> 0.8'}
@@ -7027,6 +7030,10 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@1.29.2:
@@ -9441,7 +9448,7 @@ snapshots:
       hookable: 5.5.3
       image-meta: 0.2.2
       is-installed-globally: 1.0.0
-      launch-editor: 2.12.0
+      launch-editor: 2.14.1
       local-pkg: 1.1.2
       magicast: 0.5.1
       nypm: 0.6.2
@@ -9482,7 +9489,7 @@ snapshots:
       hookable: 5.5.3
       image-meta: 0.2.2
       is-installed-globally: 1.0.0
-      launch-editor: 2.12.0
+      launch-editor: 2.14.1
       local-pkg: 1.1.2
       magicast: 0.5.1
       nypm: 0.6.2
@@ -13402,6 +13409,11 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.8.4
+
   lazy-ass@1.6.0: {}
 
   lazystream@1.0.1:
@@ -15466,6 +15478,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shell-quote@1.8.4: {}
 
   shiki@1.29.2:
     dependencies:


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

Bumps `launch-editor` from `^2.9.1` to `^2.14.0` in `@histoire/plugin-vue`.

`launch-editor@2.14.0` is the first release to depend on `shell-quote@^1.8.4`, which fixes the critical command-injection advisory GHSA-w7jw-789q-3m8p (CVE-2026-9277). Earlier `launch-editor` releases pull `shell-quote@<=1.8.3`, whose `quote()` does not escape line terminators in object `.op` values.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
