### PR TITLE
fix(histoire): ignore deps under hidden roots

### DIFF
--- a/packages/histoire/src/node/__tests__/markdown.spec.ts
+++ b/packages/histoire/src/node/__tests__/markdown.spec.ts
@@ -3,7 +3,7 @@ import { createWriteStream, unlinkSync } from 'node:fs'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createContext } from '../context.js'
-import { createMarkdownFilesWatcher } from '../markdown.js'
+import { createMarkdownFilesWatcher, isMarkdownFileIgnored } from '../markdown.js'
 import { watchStories } from '../stories.js'
 
 describe('markdown', async () => {
@@ -31,13 +31,21 @@ describe('markdown', async () => {
     // test 2 links to test1
     const { stop } = await createMarkdownFilesWatcher(ctx)
     expect(ctx.markdownFiles.length).toEqual(2)
-    stop()
+    await stop()
   })
 
   it('should render html from md', async () => {
     const { stop } = await createMarkdownFilesWatcher(ctx)
     expect(ctx.markdownFiles[0].html).toContain('<p>')
-    stop()
+    await stop()
+  })
+
+  it('ignores dependencies when the project root has a hidden parent', async () => {
+    const root = path.join(path.parse(ctx.root).root, '.worktrees', 'project')
+    ctx.root = root
+
+    expect(isMarkdownFileIgnored(ctx, path.join(root, 'node_modules', 'dependency'))).toBe(true)
+    expect(isMarkdownFileIgnored(ctx, path.join(root, 'example.story.md'), { isFile: () => true })).toBe(false)
   })
 
   it('should throw error on missing [md] story file.', async () => {

--- a/packages/histoire/src/node/markdown.ts
+++ b/packages/histoire/src/node/markdown.ts
@@ -134,21 +134,27 @@ export async function createMarkdownPlugins(ctx: Context) {
   return plugins
 }
 
+export function isMarkdownFileIgnored(ctx: Context, filePath: string, stats?: { isFile: () => boolean }) {
+  const relativePath = path.relative(ctx.root, filePath)
+  if (ctx.config.storyIgnored.some(pattern => (
+    micromatch.isMatch(relativePath, pattern, { dot: true })
+    || micromatch.isMatch(filePath, pattern, { dot: true })
+  ))) {
+    return true
+  }
+  if (micromatch.isMatch(relativePath, '**/*.story.md')) {
+    return false
+  }
+
+  return stats?.isFile() ?? false
+}
+
 export async function createMarkdownFilesWatcher(ctx: Context) {
   const md = await createMarkdownRendererWithPlugins(ctx)
 
   const watcher = chokidar.watch('.', {
     cwd: ctx.root,
-    ignored: (path, stats) => {
-      if (ctx.config.storyIgnored.some(pattern => micromatch.isMatch(path, pattern))) {
-        return true
-      }
-      if (micromatch.isMatch(path, '**/*.story.md')) {
-        return false
-      }
-
-      return stats?.isFile()
-    },
+    ignored: (filePath, stats) => isMarkdownFileIgnored(ctx, filePath, stats),
   })
 
   /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Normalize Markdown watcher paths before applying ignore globs so hidden parent directories do not cause dependency traversal.

Fix #847

### Additional context

N/A

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [X] Read the [Contributing Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/Akryum/histoire/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/histoire/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
